### PR TITLE
refactor: use julia extension 

### DIFF
--- a/examples/demo.pluto.jl
+++ b/examples/demo.pluto.jl
@@ -1,0 +1,320 @@
+### A Pluto.jl notebook ###
+# v0.19.40
+
+using Markdown
+using InteractiveUtils
+
+# This cell contains imports that will be used throughout the notebook
+
+# ╔═╡ 8e6f3a40-9e3a-4fee-8f5e-0fb8c1c8e8e8
+#VSCODE-MARKDOWN
+md"""
+# Pluto Notebook Demo
+This is an example Pluto notebook demonstrating various features.
+"""
+
+# ╔═╡ a1b2c3d4-9e3a-41ee-9234-0fb8c1c8e8e8
+# Basic Julia computation
+x = 5
+
+# ╔═╡ b2c3d4e5-9e3a-41ee-a345-0fb8c1c8e8e8
+y = x^2 + 2x - 1
+
+# ╔═╡ c3d4e5f6-9e3a-41ee-b456-0fb8c1c8e8e8
+md"""
+The value of y is **$(y)**
+"""
+
+# ╔═╡ d4e5f6a7-9e3a-41ee-8567-0fb8c1c8e8e8
+# Array operations
+data = [1, 2, 3, 4, 5]
+
+# ╔═╡ e5f6a7b8-9e3a-41ee-9678-0fb8c1c8e8e8
+squared_data = data .^ 2
+
+# ╔═╡ f6a7b8c9-9e3a-41ee-a789-0fb8c1c8e8e8
+sum_squared = sum(squared_data)
+
+# ╔═╡ a7b8c9d0-9e3a-41ee-b890-0fb8c1c8e8e8
+#VSCODE-MARKDOWN
+md"""
+## Interactive Widgets
+Pluto supports interactive widgets using `@bind`
+"""
+
+# ╔═╡ b8c9d0e1-9e3a-41ee-8901-0fb8c1c8e8e8
+begin
+    import Pkg
+    Pkg.add("PlutoUI")
+end
+
+# ╔═╡ c9d0e1f2-9e3a-41ee-9012-0fb8c1c8e8e8
+using PlutoUI
+
+# ╔═╡ d0e1f2a3-9e3a-41ee-8123-0fb8c1c8e8e8
+@bind n Slider(1:100, default=10, show_value=true)
+
+# ╔═╡ e1f2a3b4-9e3a-41ee-9234-0fb8c1c8e8e8
+md"""
+You selected: **$(n)**
+"""
+
+# ╔═╡ f2a3b4c5-9e3a-41ee-a345-0fb8c1c8e8e8
+# Reactive computation based on slider
+fibonacci_n = let
+    a, b = 0, 1
+    for i in 1:n
+        a, b = b, a + b
+    end
+    a
+end
+
+# ╔═╡ a3b4c5d6-9e3a-41ee-b456-0fb8c1c8e8e8
+md"""
+The $(n)th Fibonacci number is: **$(fibonacci_n)**
+"""
+
+# ╔═╡ b4c5d6e7-9e3a-41ee-8567-0fb8c1c8e8e8
+md"""
+## Text Input Widget
+"""
+
+# ╔═╡ c5d6e7f8-9e3a-41ee-9678-0fb8c1c8e8e8
+@bind name TextField(default="World")
+
+# ╔═╡ d6e7f8a9-9e3a-41ee-a789-0fb8c1c8e8e8
+md"""
+Hello, **$(name)**! 👋
+"""
+
+# ╔═╡ e7f8a9b0-9e3a-41ee-b890-0fb8c1c8e8e8
+md"""
+## Plotting
+Let's create some visualizations using Plots.jl
+"""
+
+# ╔═╡ f8a9b0c1-9e3a-41ee-8901-0fb8c1c8e8e8
+begin
+    Pkg.add("Plots")
+end
+
+# ╔═╡ a9b0c1d2-9e3a-41ee-9012-0fb8c1c8e8e8
+using Plots
+
+# ╔═╡ b0c1d2e3-9e3a-41ee-8123-0fb8c1c8e8e8
+# Simple line plot
+plot(1:10, (1:10) .^ 2,
+    label="y = x²",
+    xlabel="x",
+    ylabel="y",
+    title="Quadratic Function",
+    linewidth=2,
+    color=:blue,
+    legend=:topleft)
+
+# ╔═╡ c1d2e3f4-9e3a-41ee-9234-0fb8c1c8e8e8
+# Multiple functions on same plot
+let
+    x_range = -2π:0.1:2π
+    plot(x_range, sin.(x_range), label="sin(x)", linewidth=2)
+    plot!(x_range, cos.(x_range), label="cos(x)", linewidth=2)
+    plot!(x_range, sin.(x_range) .* cos.(x_range), label="sin(x)·cos(x)", linewidth=2)
+    xlabel!("x")
+    ylabel!("y")
+    title!("Trigonometric Functions")
+end
+
+# ╔═╡ d2e3f4a5-9e3a-41ee-a345-0fb8c1c8e8e8
+# Scatter plot
+scatter(randn(100), randn(100),
+    alpha=0.5,
+    markersize=8,
+    color=:purple,
+    xlabel="X",
+    ylabel="Y",
+    title="Random Scatter Plot",
+    legend=false)
+
+# ╔═╡ e3f4a5b6-9e3a-41ee-b456-0fb8c1c8e8e8
+md"""
+## Interactive Plot
+Control the plot parameters with widgets!
+"""
+
+# ╔═╡ f4a5b6c7-9e3a-41ee-8567-0fb8c1c8e8e8
+@bind amplitude Slider(0.5:0.1:3.0, default=1.0, show_value=true)
+
+# ╔═╡ a5b6c7d8-9e3a-41ee-9678-0fb8c1c8e8e8
+@bind frequency Slider(1:10, default=2, show_value=true)
+
+# ╔═╡ b6c7d8e9-9e3a-41ee-a789-0fb8c1c8e8e8
+md"""
+- Amplitude: $(amplitude)
+- Frequency: $(frequency)
+"""
+
+# ╔═╡ c7d8e9f0-9e3a-41ee-b890-0fb8c1c8e8e8
+# Interactive sine wave
+let
+    x = 0:0.01:4π
+    y = amplitude .* sin.(frequency .* x)
+    plot(x, y,
+        linewidth=3,
+        color=:red,
+        xlabel="x",
+        ylabel="y",
+        title="Interactive Sine Wave: y = $(amplitude) · sin($(frequency)x)",
+        legend=false,
+        ylim=(-3.5, 3.5))
+end
+
+# ╔═╡ d8e9f0a1-9e3a-41ee-8901-0fb8c1c8e8e8
+md"""
+## Heatmap Example
+"""
+
+# ╔═╡ e9f0a1b2-9e3a-41ee-9012-0fb8c1c8e8e8
+# Generate data for heatmap
+heatmap_data = [sin(x) * cos(y) for x in range(0, 2π, length=50), y in range(0, 2π, length=50)]
+
+# ╔═╡ f0a1b2c3-9e3a-41ee-8123-0fb8c1c8e8e8
+heatmap(heatmap_data,
+    color=:viridis,
+    xlabel="X",
+    ylabel="Y",
+    title="sin(x) · cos(y) Heatmap",
+    aspect_ratio=:equal)
+
+# ╔═╡ a1b2c3d4-9e3a-41ee-9234-5fb8c1c8e8e9
+md"""
+## Mathematical Expressions
+Pluto supports LaTeX math rendering:
+
+$e^{i\pi} + 1 = 0$
+
+The quadratic formula:
+$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$
+"""
+
+# ╔═╡ b2c3d4e5-9e3a-41ee-a345-5fb8c1c8e8e9
+md"""
+## Data Structures
+"""
+
+# ╔═╡ c3d4e5f6-9e3a-41ee-b456-5fb8c1c8e8e9
+# Dictionary
+person = Dict(
+    "name" => "Alice",
+    "age" => 30,
+    "city" => "New York"
+)
+
+# ╔═╡ d4e5f6a7-9e3a-41ee-8567-5fb8c1c8e8e9
+# Named tuple
+point = (x=10, y=20, z=30)
+
+# ╔═╡ e5f6a7b8-9e3a-41ee-9678-5fb8c1c8e8e9
+md"""
+Person: $(person["name"]), Age: $(person["age"])
+
+Point coordinates: ($(point.x), $(point.y), $(point.z))
+"""
+
+# ╔═╡ f6a7b8c9-9e3a-41ee-a789-5fb8c1c8e8e9
+md"""
+## Functions
+"""
+
+# ╔═╡ a7b8c9d0-9e3a-41ee-b890-5fb8c1c8e8e9
+function greet(name, greeting="Hello")
+    return "$greeting, $name!"
+end
+
+# ╔═╡ b8c9d0e1-9e3a-41ee-8901-5fb8c1c8e8e9
+greet("Julia")
+
+# ╔═╡ c9d0e1f2-9e3a-41ee-9012-5fb8c1c8e8e9
+greet("Pluto", "Welcome")
+
+# ╔═╡ d0e1f2a3-9e3a-41ee-8123-5fb8c1c8e8e0
+md"""
+## Reactive Programming
+One of Pluto's superpowers is reactive programming - when you change a variable, all cells that depend on it automatically re-run!
+"""
+
+# ╔═╡ 00000000-0000-0000-0000-000000000001
+PLUTO_PROJECT_TOML_CONTENTS = """
+[deps]
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+PlutoUI = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
+
+[compat]
+Plots = "~1.39.0"
+PlutoUI = "~0.7.54"
+"""
+
+# ╔═╡ 00000000-0000-0000-0000-000000000002
+PLUTO_MANIFEST_TOML_CONTENTS = """
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.10.0"
+manifest_format = "2.0"
+project_hash = "abcd1234"
+
+[[deps.Plots]]
+deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "JLFzf", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "PrecompileTools", "Preferences", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "RelocatableFolders", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "UnitfulLatexify", "Unzip"]
+git-tree-sha1 = "ccee59c6e48e6f2edf8a5b64dc817b6729f99eb5"
+uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+version = "1.39.0"
+
+[[deps.PlutoUI]]
+deps = ["AbstractPlutoDingetjes", "Base64", "ColorTypes", "Dates", "FixedPointNumbers", "Hyperscript", "HypertextLiteral", "IOCapture", "InteractiveUtils", "JSON", "Logging", "MIMEs", "Markdown", "Random", "Reexport", "URIs", "UUIDs"]
+git-tree-sha1 = "bd7c69c7f7173097e7b5e1be07cee2b8b7447f51"
+uuid = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
+version = "0.7.54"
+"""
+
+# ╔═╡ Cell order:
+# ╟─8e6f3a40-9e3a-4fee-8f5e-0fb8c1c8e8e8
+# ╠═a1b2c3d4-9e3a-41ee-9234-0fb8c1c8e8e8
+# ╠═b2c3d4e5-9e3a-41ee-a345-0fb8c1c8e8e8
+# ╟─c3d4e5f6-9e3a-41ee-b456-0fb8c1c8e8e8
+# ╠═d4e5f6a7-9e3a-41ee-8567-0fb8c1c8e8e8
+# ╠═e5f6a7b8-9e3a-41ee-9678-0fb8c1c8e8e8
+# ╠═f6a7b8c9-9e3a-41ee-a789-0fb8c1c8e8e8
+# ╟─a7b8c9d0-9e3a-41ee-b890-0fb8c1c8e8e8
+# ╠═b8c9d0e1-9e3a-41ee-8901-0fb8c1c8e8e8
+# ╠═c9d0e1f2-9e3a-41ee-9012-0fb8c1c8e8e8
+# ╟─d0e1f2a3-9e3a-41ee-8123-0fb8c1c8e8e8
+# ╟─e1f2a3b4-9e3a-41ee-9234-0fb8c1c8e8e8
+# ╠═f2a3b4c5-9e3a-41ee-a345-0fb8c1c8e8e8
+# ╟─a3b4c5d6-9e3a-41ee-b456-0fb8c1c8e8e8
+# ╟─b4c5d6e7-9e3a-41ee-8567-0fb8c1c8e8e8
+# ╟─c5d6e7f8-9e3a-41ee-9678-0fb8c1c8e8e8
+# ╟─d6e7f8a9-9e3a-41ee-a789-0fb8c1c8e8e8
+# ╟─e7f8a9b0-9e3a-41ee-b890-0fb8c1c8e8e8
+# ╠═f8a9b0c1-9e3a-41ee-8901-0fb8c1c8e8e8
+# ╠═a9b0c1d2-9e3a-41ee-9012-0fb8c1c8e8e8
+# ╠═b0c1d2e3-9e3a-41ee-8123-0fb8c1c8e8e8
+# ╠═c1d2e3f4-9e3a-41ee-9234-0fb8c1c8e8e8
+# ╠═d2e3f4a5-9e3a-41ee-a345-0fb8c1c8e8e8
+# ╟─e3f4a5b6-9e3a-41ee-b456-0fb8c1c8e8e8
+# ╟─f4a5b6c7-9e3a-41ee-8567-0fb8c1c8e8e8
+# ╟─a5b6c7d8-9e3a-41ee-9678-0fb8c1c8e8e8
+# ╟─b6c7d8e9-9e3a-41ee-a789-0fb8c1c8e8e8
+# ╠═c7d8e9f0-9e3a-41ee-b890-0fb8c1c8e8e8
+# ╟─d8e9f0a1-9e3a-41ee-8901-0fb8c1c8e8e8
+# ╠═e9f0a1b2-9e3a-41ee-9012-0fb8c1c8e8e8
+# ╠═f0a1b2c3-9e3a-41ee-8123-0fb8c1c8e8e8
+# ╟─a1b2c3d4-9e3a-41ee-9234-5fb8c1c8e8e9
+# ╟─b2c3d4e5-9e3a-41ee-a345-5fb8c1c8e8e9
+# ╠═c3d4e5f6-9e3a-41ee-b456-5fb8c1c8e8e9
+# ╠═d4e5f6a7-9e3a-41ee-8567-5fb8c1c8e8e9
+# ╟─e5f6a7b8-9e3a-41ee-9678-5fb8c1c8e8e9
+# ╟─f6a7b8c9-9e3a-41ee-a789-5fb8c1c8e8e9
+# ╠═a7b8c9d0-9e3a-41ee-b890-5fb8c1c8e8e9
+# ╠═b8c9d0e1-9e3a-41ee-8901-5fb8c1c8e8e9
+# ╠═c9d0e1f2-9e3a-41ee-9012-5fb8c1c8e8e9
+# ╟─d0e1f2a3-9e3a-41ee-8123-5fb8c1c8e8e0
+# ╟─00000000-0000-0000-0000-000000000001
+# ╟─00000000-0000-0000-0000-000000000002

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "advanced-vscode-extension",
-  "version": "0.2.4",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "advanced-vscode-extension",
-      "version": "0.2.4",
+      "version": "0.2.7",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",
         "@plutojl/rainbow": "^0.6.19",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   "activationEvents": [
     "onNotebook:pluto-notebook"
   ],
+  "extensionDependencies": [
+    "julialang.language-julia"
+  ],
   "main": "./dist/extension.cjs",
   "contributes": {
     "configuration": {
@@ -51,8 +54,8 @@
         },
         "pluto-notebook.juliaVersion": {
           "type": "string",
-          "default": "1.11.7",
-          "description": "Julia version to use with juliaup (e.g., '1.11.7', '1.10.0', 'release'). The extension will automatically install this version via juliaup if not already available."
+          "default": "",
+          "description": "Fallback Julia version for juliaup when the Julia extension is unavailable (e.g. '1.11.7'). Normally the active Julia channel is sourced from the julialang.language-julia extension."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "onNotebook:pluto-notebook"
   ],
   "extensionDependencies": [
-    "julialang.language-julia"
+    "julialang.language-julia",
+    "JuliaComputing.juliahub-vscode-auth"
   ],
   "main": "./dist/extension.cjs",
   "contributes": {

--- a/src/julia-utils.ts
+++ b/src/julia-utils.ts
@@ -58,7 +58,10 @@ function getJuliaAPI(): vscode.Extension<JuliaExtAPI> | undefined {
 
 export async function activateJulia(): Promise<vscode.Extension<JuliaExtAPI>> {
   const api = getJuliaAPI();
-  if (!api) throw new Error("Julia language extension (julialang.language-julia) not found");
+  if (!api)
+    throw new Error(
+      "Julia language extension (julialang.language-julia) not found"
+    );
   if (!api.isActive) await api.activate();
   return api;
 }
@@ -90,9 +93,8 @@ export async function getJuliaExecutable(): Promise<{
 
 function getFallbackJuliaCommand(): string {
   return (
-    vscode.workspace
-      .getConfiguration("julia")
-      .get<string>("executablePath") ?? getExecutableName("julia")
+    vscode.workspace.getConfiguration("julia").get<string>("executablePath") ??
+    getExecutableName("julia")
   );
 }
 
@@ -107,9 +109,8 @@ export async function getPackageServer(): Promise<string | undefined> {
     return server || undefined;
   } catch {
     return (
-      vscode.workspace
-        .getConfiguration("julia")
-        .get<string>("packageServer") || undefined
+      vscode.workspace.getConfiguration("julia").get<string>("packageServer") ||
+      undefined
     );
   }
 }

--- a/src/julia-utils.ts
+++ b/src/julia-utils.ts
@@ -1,0 +1,162 @@
+import * as vscode from "vscode";
+import { getExecutableName } from "./platformUtils.ts";
+
+// ---------------------------------------------------------------------------
+// Julia extension API types
+// ---------------------------------------------------------------------------
+
+interface JuliaChannelInfo {
+  name: string;
+  file: string;
+  args: string[];
+  version: string;
+  arch: string;
+  isDefault: boolean;
+}
+
+interface JuliaExecutableInfo {
+  /** Resolved command path (new API) */
+  command: string;
+  /** Resolved command path (old API, backward compat) */
+  file?: string;
+  version: string;
+  args: string[];
+  channel: JuliaChannelInfo;
+}
+
+interface JuliaExtAPI {
+  version: number;
+  getJuliaExecutable: () => Promise<JuliaExecutableInfo>;
+  getEnvironment: () => Promise<string>;
+  getPkgServer: () => string;
+  installJuliaOrJuliaup: (
+    taskName: string,
+    customCommand?: string
+  ) => Promise<number | void>;
+}
+
+// ---------------------------------------------------------------------------
+// JuliaHub auth extension API types (optional dependency)
+// ---------------------------------------------------------------------------
+
+interface JuliaHubAuthAPI {
+  version: number;
+  getJuliaHubServer: () => string;
+  onDidChangeServer: vscode.Event<string>;
+  authenticate: (server?: string, force?: boolean) => Promise<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Julia extension helpers
+// ---------------------------------------------------------------------------
+
+function getJuliaAPI(): vscode.Extension<JuliaExtAPI> | undefined {
+  return vscode.extensions.getExtension<JuliaExtAPI>(
+    "julialang.language-julia"
+  );
+}
+
+export async function activateJulia(): Promise<vscode.Extension<JuliaExtAPI>> {
+  const api = getJuliaAPI();
+  if (!api) throw new Error("Julia language extension (julialang.language-julia) not found");
+  if (!api.isActive) await api.activate();
+  return api;
+}
+
+/**
+ * Returns the Julia executable command and any channel args (e.g. `+1.11.7`)
+ * from the active Julia extension configuration.
+ *
+ * Falls back to `julia.executablePath` workspace config, then to the plain
+ * `julia` / `julia.exe` executable name if the extension API is unavailable.
+ */
+export async function getJuliaExecutable(): Promise<{
+  command: string;
+  args: string[];
+}> {
+  try {
+    const api = await activateJulia();
+    const exe = await api.exports.getJuliaExecutable();
+    const command = exe?.command ?? exe?.file ?? getFallbackJuliaCommand();
+    return { command, args: exe?.args ?? [] };
+  } catch (err) {
+    console.warn(
+      "[julia-utils] Could not get Julia executable from extension, falling back:",
+      err
+    );
+    return { command: getFallbackJuliaCommand(), args: [] };
+  }
+}
+
+function getFallbackJuliaCommand(): string {
+  return (
+    vscode.workspace
+      .getConfiguration("julia")
+      .get<string>("executablePath") ?? getExecutableName("julia")
+  );
+}
+
+/**
+ * Returns the active Julia package server URL from the Julia extension.
+ * Falls back to `julia.packageServer` workspace config, then undefined.
+ */
+export async function getPackageServer(): Promise<string | undefined> {
+  try {
+    const api = await activateJulia();
+    const server = api.exports.getPkgServer();
+    return server || undefined;
+  } catch {
+    return (
+      vscode.workspace
+        .getConfiguration("julia")
+        .get<string>("packageServer") || undefined
+    );
+  }
+}
+
+/**
+ * Runs a Julia package manager command via the Julia extension's integrated
+ * REPL (`language-julia.runPackageCommand`). This respects the active Julia
+ * channel and depot without requiring subprocess management.
+ *
+ * Adopted from https://github.dev/julia-vscode/julia-vscode
+ */
+export async function runPackageCommand(
+  command: string,
+  workspace: string
+): Promise<void> {
+  await activateJulia();
+  await vscode.commands.executeCommand(
+    "language-julia.runPackageCommand",
+    command,
+    workspace
+  );
+}
+
+// ---------------------------------------------------------------------------
+// JuliaHub auth extension helpers (optional)
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempts to retrieve a JuliaHub authentication token via the
+ * `JuliaComputing.juliahub-vscode-auth` extension.
+ *
+ * Returns `undefined` if the auth extension is not installed, so callers
+ * must not block Pluto startup on this value.
+ */
+export async function getJuliaHubToken(
+  hostname?: string
+): Promise<string | undefined> {
+  const ext = vscode.extensions.getExtension<JuliaHubAuthAPI>(
+    "JuliaComputing.juliahub-vscode-auth"
+  );
+  if (!ext) return undefined;
+  try {
+    if (!ext.isActive) await ext.activate();
+    const server = hostname ? `https://${hostname}` : undefined;
+    return await ext.exports.authenticate(server);
+  } catch (err) {
+    console.warn("[julia-utils] JuliaHub auth failed:", err);
+    return undefined;
+  }
+}

--- a/src/julia-utils.ts
+++ b/src/julia-utils.ts
@@ -36,7 +36,7 @@ interface JuliaExtAPI {
 }
 
 // ---------------------------------------------------------------------------
-// JuliaHub auth extension API types (optional dependency)
+// JuliaHub auth extension API types
 // ---------------------------------------------------------------------------
 
 interface JuliaHubAuthAPI {
@@ -134,29 +134,27 @@ export async function runPackageCommand(
 }
 
 // ---------------------------------------------------------------------------
-// JuliaHub auth extension helpers (optional)
+// JuliaHub auth extension helpers
 // ---------------------------------------------------------------------------
 
 /**
- * Attempts to retrieve a JuliaHub authentication token via the
+ * Retrieves a JuliaHub authentication token via the
  * `JuliaComputing.juliahub-vscode-auth` extension.
  *
- * Returns `undefined` if the auth extension is not installed, so callers
- * must not block Pluto startup on this value.
+ * Throws if the extension is not installed or authentication fails.
+ * The extension is listed in `extensionDependencies` so it is guaranteed
+ * to be present at activation time.
  */
-export async function getJuliaHubToken(
-  hostname?: string
-): Promise<string | undefined> {
+export async function getJuliaHubToken(hostname?: string): Promise<string> {
   const ext = vscode.extensions.getExtension<JuliaHubAuthAPI>(
     "JuliaComputing.juliahub-vscode-auth"
   );
-  if (!ext) return undefined;
-  try {
-    if (!ext.isActive) await ext.activate();
-    const server = hostname ? `https://${hostname}` : undefined;
-    return await ext.exports.authenticate(server);
-  } catch (err) {
-    console.warn("[julia-utils] JuliaHub auth failed:", err);
-    return undefined;
+  if (!ext) {
+    throw new Error(
+      "JuliaHub auth extension (JuliaComputing.juliahub-vscode-auth) not found"
+    );
   }
+  if (!ext.isActive) await ext.activate();
+  const server = hostname ? `https://${hostname}` : undefined;
+  return await ext.exports.authenticate(server);
 }

--- a/src/plutoServerTask.ts
+++ b/src/plutoServerTask.ts
@@ -174,11 +174,9 @@ export class PlutoServerTaskManager {
       port: this.actualPort,
     };
 
-    const processExecution = new vscode.ProcessExecution(
-      command,
-      juliaArgs,
-      { env }
-    );
+    const processExecution = new vscode.ProcessExecution(command, juliaArgs, {
+      env,
+    });
 
     const task = new vscode.Task(
       taskDefinition,

--- a/src/plutoServerTask.ts
+++ b/src/plutoServerTask.ts
@@ -143,12 +143,10 @@ export class PlutoServerTaskManager {
       JULIA_PLUTO_VSCODE_WORKSPACE: workspacePath,
       JULIA_DEPOT_PATH: path.join(os.homedir(), ".julia"),
       JULIA_LOAD_PATH: isWindows() ? ";" : ":",
+      JULIAHUB_TOKEN: juliaHubToken,
     };
     if (packageServer) {
       env.JULIA_PKG_SERVER = packageServer;
-    }
-    if (juliaHubToken) {
-      env.JULIAHUB_TOKEN = juliaHubToken;
     }
 
     // --- Step 5: Start the Pluto server task (setup + run in one process) ---

--- a/src/plutoServerTask.ts
+++ b/src/plutoServerTask.ts
@@ -3,23 +3,12 @@ import * as os from "os";
 import * as path from "path";
 import { isDefined } from "./helpers.ts";
 import { isPortAvailable, findAvailablePort } from "./portUtils.ts";
-import { getExecutableName, isWindows } from "./platformUtils.ts";
-
-/**
- * Parse Julia executable path to extract command and arguments
- */
-function parseJuliaExecutable(executablePath: string): {
-  command: string;
-  args: string[];
-} {
-  // Split by spaces but respect quoted strings
-  const parts = executablePath.match(/(?:[^\s"]+|"[^"]*")+/g) ?? [
-    executablePath,
-  ];
-  const command = parts[0].replace(/"/g, ""); // Remove quotes from command
-  const args = parts.slice(1).map((arg) => arg.replace(/"/g, "")); // Remove quotes from args
-  return { command, args };
-}
+import { isWindows } from "./platformUtils.ts";
+import {
+  getJuliaExecutable,
+  getPackageServer,
+  getJuliaHubToken,
+} from "./julia-utils.ts";
 
 /**
  * Manages Pluto server as a VSCode task with terminal integration
@@ -104,12 +93,10 @@ export class PlutoServerTaskManager {
           `[PlutoServerTask] Found available port: ${this.actualPort}`
         );
 
-        // Notify about port change
         if (this.onPortChangedCallback && this.actualPort !== this.port) {
           this.onPortChangedCallback(this.actualPort);
         }
 
-        // Show notification to user about port change
         if (this.actualPort !== this.port) {
           vscode.window.showWarningMessage(
             `Port ${this.port} is in use. Starting Pluto server on port ${this.actualPort} instead.`
@@ -134,224 +121,24 @@ export class PlutoServerTaskManager {
     const workspacePath =
       vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "";
 
-    // Get Julia settings
-    const juliaConfig = vscode.workspace.getConfiguration("julia");
-    const command = getExecutableName("julia");
-    //TODO: play well with juliaConfig.get<string>("executablePath")
-    const executablePath = command;
-
-    // Get Pluto extension settings
-    const plutoConfig = vscode.workspace.getConfiguration("pluto-notebook");
-    const juliaVersion = plutoConfig.get<string>("juliaVersion") || "1.11.7";
-
-    // Ensure configured Julia version is installed via juliaup
-    const juliaupCommand = getExecutableName("juliaup");
-    try {
-      console.log(
-        `[PlutoServerTask] Checking if Julia ${juliaVersion} is available via juliaup`
-      );
-
-      const juliaupTaskDefinition: vscode.TaskDefinition = {
-        type: "juliaup-add",
-      };
-
-      const juliaupExecution = new vscode.ShellExecution(juliaupCommand, [
-        "add",
-        juliaVersion,
-      ]);
-
-      const juliaupTask = new vscode.Task(
-        juliaupTaskDefinition,
-        vscode.TaskScope.Workspace,
-        `Pluto Server (port ${this.actualPort})`,
-        "pluto-notebook",
-        juliaupExecution,
-        []
-      );
-      juliaupTask.isBackground = false;
-      juliaupTask.presentationOptions = {
-        reveal: vscode.TaskRevealKind.Always,
-        panel: vscode.TaskPanelKind.Shared,
-        showReuseMessage: false,
-        clear: false,
-        focus: false,
-        echo: true,
-      };
-
-      const juliaupTaskExecution = await vscode.tasks.executeTask(juliaupTask);
-      await new Promise<void>((resolve, reject) => {
-        const disposable = vscode.tasks.onDidEndTaskProcess((e) => {
-          if (e.execution === juliaupTaskExecution) {
-            disposable.dispose();
-            if (e.exitCode === 0) {
-              console.log(
-                `[PlutoServerTask] Julia ${juliaVersion} installed/verified successfully`
-              );
-              resolve();
-            } else {
-              reject(
-                new Error(`juliaup add failed with exit code ${e.exitCode}`)
-              );
-            }
-          }
-        });
-      });
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      console.error(
-        `[PlutoServerTask] juliaup command failed: ${errorMessage}`
-      );
-
-      const action = await vscode.window.showErrorMessage(
-        `Failed to install Julia ${juliaVersion} via juliaup. Please ensure juliaup is installed.`,
-        "Install juliaup",
-        "Continue anyway"
-      );
-
-      if (action === "Install juliaup") {
-        await vscode.env.openExternal(
-          vscode.Uri.parse("https://github.com/JuliaLang/juliaup#installation")
-        );
-        throw new Error("Please install juliaup and try again");
-      }
-      // If "Continue anyway" is selected, proceed without juliaup check
-    }
-
-    let packageServer = juliaConfig.get<string>("packageServer") ?? "";
-    if (packageServer) {
-      console.log("[PlutoServerTask] Found pkgserver in julia extension");
-    }
-    if (workspacePath) {
-      try {
-        console.log(
-          "[PlutoServerTask] Attempting to read JuliaHub configuration from 'jh auth env'"
-        );
-
-        // Create a temporary file path for the auth output
-        const authOutputUri = vscode.Uri.joinPath(
-          vscode.Uri.file(workspacePath),
-          ".vscode-pluto-auth-tmp.txt"
-        );
-
-        // Julia script that runs `jh auth env` and writes output to file
-        const jhCommand = getExecutableName("jh");
-        // Pass the auth file path via environment variable to avoid any escaping issues
-        const juliaScript = `
-          s = string; auth_path = ENV[s(:VSCODE_PLUTO_AUTH_FILE)]
-try output = read(\`${jhCommand} auth env\`, String)
-    open(io -> write(io, output), auth_path, s(:w))
-catch e
-    open(io -> write(io, s()), auth_path, s(:w))
-end
-try read(\`${jhCommand} auth refresh\`, String)
-catch e;
-end`
-          .replaceAll("\n", ";")
-          .trim();
-
-        // Create task to run the Julia script
-        const authTaskDefinition: vscode.TaskDefinition = {
-          type: "pluto-auth-setup",
-        };
-
-        const authExecution = new vscode.ProcessExecution(
-          command,
-          ["-e", juliaScript],
-          {
-            env: {
-              CODE: juliaScript,
-              VSCODE_PLUTO_AUTH_FILE: authOutputUri.fsPath,
-              JULIA_DEPOT_PATH: path.join(os.homedir(), ".julia"),
-            },
-          }
-        );
-
-        const authTask = new vscode.Task(
-          authTaskDefinition,
-          vscode.TaskScope.Workspace,
-          "Attempt to setup auth",
-          "pluto-notebook",
-          authExecution,
-          []
-        );
-        authTask.isBackground = false;
-        authTask.presentationOptions = {
-          reveal: vscode.TaskRevealKind.Never,
-          echo: false,
-          focus: false,
-          panel: vscode.TaskPanelKind.Shared,
-          showReuseMessage: false,
-          clear: false,
-        };
-
-        const authTaskExecution = await vscode.tasks.executeTask(authTask);
-
-        // Wait for task to complete (with timeout)
-        await new Promise<void>((resolve, reject) => {
-          const disposable = vscode.tasks.onDidEndTaskProcess((e) => {
-            if (e.execution === authTaskExecution) {
-              disposable.dispose();
-              resolve();
-            }
-          });
-
-          setTimeout(() => {
-            disposable.dispose();
-            reject(new Error("Auth setup timeout"));
-          }, 10000);
-        });
-
-        // Read the output file
-        try {
-          const fileContent = await vscode.workspace.fs.readFile(authOutputUri);
-          const result = new TextDecoder().decode(fileContent);
-
-          // Parse KEY=VALUE pairs
-          const envVars: Record<string, string> = {};
-          for (const line of result.split("\n")) {
-            const trimmed = line.trim();
-            if (trimmed && trimmed.includes("=")) {
-              const [key, ...valueParts] = trimmed.split("=");
-              const value = valueParts.join("="); // Handle values with '=' in them
-              envVars[key.trim()] = value.trim();
-            }
-          }
-
-          // Use JULIAHUB_HOST if available
-          if (envVars.JULIAHUB_HOST) {
-            packageServer = envVars.JULIAHUB_HOST;
-            console.log(
-              `[PlutoServerTask] Using JULIAHUB_HOST from 'jh auth env': ${packageServer}`
-            );
-          }
-        } finally {
-          // Delete the temporary file
-          try {
-            await vscode.workspace.fs.delete(authOutputUri);
-          } catch {
-            // Ignore deletion errors
-          }
-        }
-      } catch {
-        // Task failed or timed out - this is fine, just continue
-        console.log(
-          "[PlutoServerTask] Could not read 'jh auth env' (command may not be available)"
-        );
-      }
-    }
-    // Parse Julia executable to handle arguments like --sysimage
-    const { args: baseArgs } = parseJuliaExecutable(executablePath);
-
-    // Build Julia command arguments
-    const runPlutoCode = `import Pkg;s = string;Pkg.activate(mkpath(joinpath(Pkg.depots1(), s(:environments), s(:vscode_pluto_notebook), string(VERSION))));using Pluto; Pluto.run(port=${this.actualPort}; require_secret_for_open_links=false, require_secret_for_access=false, launch_browser=false)`;
-    const juliaArgs = [`+${juliaVersion}`, ...baseArgs, "-e", runPlutoCode];
-
+    // --- Step 1: Get Julia executable from the Julia extension ---
+    // Julia is guaranteed installed because julialang.language-julia is an extensionDependency.
+    const { command, args: channelArgs } = await getJuliaExecutable();
     console.log(
-      `[PlutoServerTask] Resolved command: ${command} ${juliaArgs.join(" ")}`
+      `[PlutoServerTask] Julia executable: ${command} ${channelArgs.join(" ")}`
     );
 
-    // Build environment variables
+    // --- Step 3: Get package server and optional JuliaHub token ---
+    const packageServer = await getPackageServer();
+    if (packageServer) {
+      console.log(
+        `[PlutoServerTask] Package server from Julia extension: ${packageServer}`
+      );
+    }
+
+    const juliaHubToken = await getJuliaHubToken();
+
+    // --- Step 4: Build env vars for the server process ---
     const env: { [key: string]: string } = {
       JULIA_PLUTO_VSCODE_WORKSPACE: workspacePath,
       JULIA_DEPOT_PATH: path.join(os.homedir(), ".julia"),
@@ -360,88 +147,50 @@ end`
     if (packageServer) {
       env.JULIA_PKG_SERVER = packageServer;
     }
+    if (juliaHubToken) {
+      env.JULIAHUB_TOKEN = juliaHubToken;
+    }
 
-    const setupTaskDefinition: vscode.TaskDefinition = {
-      type: "pluto-setup",
-    };
+    // --- Step 5: Start the Pluto server task (setup + run in one process) ---
+    // Setup steps run first in the same Julia session, then Pluto.run() blocks.
+    const serverCode = [
+      `import Pkg`,
+      `s = string`,
+      `Pkg.activate(mkpath(joinpath(Pkg.depots1(), s(:environments), s(:vscode_pluto_notebook), string(VERSION))))`,
+      `Pkg.Registry.add()`,
+      `Pkg.add(s(:Pluto))`,
+      `Pkg.add(s(:Pkg))`,
+      `Pkg.instantiate()`,
+      `Pkg.precompile()`,
+      `using Pluto`,
+      `Pluto.run(port=${this.actualPort}; require_secret_for_open_links=false, require_secret_for_access=false, launch_browser=false)`,
+    ].join(";");
+    const juliaArgs = [...channelArgs, "-e", serverCode];
 
-    // Create an envrionment for the SERVER where Pluto will run in. Let julia manage paths
-    const setupCode = `import Pkg
-      s = string
-      Pkg.activate(mkpath(joinpath(Pkg.depots1(), s(:environments), s(:vscode_pluto_notebook), string(VERSION))))
-      Pkg.Registry.add()
-      Pkg.add(s(:Pluto))
-      Pkg.add(s(:Pkg))
-      Pkg.instantiate()
-      Pkg.precompile()`
-      .replaceAll("\n", ";")
-      .trim();
-    const setupExecution = new vscode.ProcessExecution(
-      command,
-      [`+${juliaVersion}`, ...baseArgs, "-e", setupCode],
-      { env }
+    console.log(
+      `[PlutoServerTask] Resolved command: ${command} ${juliaArgs.join(" ")}`
     );
 
-    const task1 = new vscode.Task(
-      setupTaskDefinition,
-      vscode.TaskScope.Workspace,
-      `Pluto Server (port ${this.actualPort})`,
-      "pluto-notebook",
-      setupExecution,
-      [] // No problem matchers
-    );
-    task1.isBackground = false;
-    task1.presentationOptions = {
-      reveal: vscode.TaskRevealKind.Always,
-      panel: vscode.TaskPanelKind.Shared,
-      showReuseMessage: false,
-      clear: false,
-      focus: false,
-      echo: true,
-    };
-
-    // Execute setup task and wait for it to complete
-    const setupExecution1 = await vscode.tasks.executeTask(task1);
-    await new Promise<void>((resolve, reject) => {
-      const disposable = vscode.tasks.onDidEndTaskProcess((e) => {
-        if (e.execution === setupExecution1) {
-          disposable.dispose();
-          if (e.exitCode === 0) {
-            console.log("[PlutoServerTask] Setup task completed successfully");
-            resolve();
-          } else {
-            reject(new Error(`Setup task failed with exit code ${e.exitCode}`));
-          }
-        }
-      });
-    });
-
-    // Create the task definition
     const taskDefinition: vscode.TaskDefinition = {
       type: "pluto-server",
       port: this.actualPort,
     };
 
-    // Create process execution for Julia command (bypasses shell to avoid quoting issues)
     const processExecution = new vscode.ProcessExecution(
       command,
-      [`+${juliaVersion}`, ...baseArgs, "-e", runPlutoCode],
-      {
-        env,
-      }
+      juliaArgs,
+      { env }
     );
 
-    // Create the task
     const task = new vscode.Task(
       taskDefinition,
       vscode.TaskScope.Workspace,
       `Pluto Server (port ${this.actualPort})`,
       "pluto-notebook",
       processExecution,
-      [] // No problem matchers
+      []
     );
 
-    // Configure task presentation - use Shared panel to reuse the same terminal as setup task
     task.presentationOptions = {
       reveal: vscode.TaskRevealKind.Always,
       panel: vscode.TaskPanelKind.Shared,
@@ -450,53 +199,43 @@ end`
       focus: false,
       echo: true,
     };
-
-    // Set as background task
     task.isBackground = true;
 
-    // Listen for task end - this will reset state when task stops
+    // Listen for task end to reset state
     this.taskEndListener = vscode.tasks.onDidEndTaskProcess((e) => {
       if (e.execution === this.taskExecution) {
-        // Task ended - reset state
         this.taskExecution = undefined;
         this.serverReadyPromise = undefined;
         this.serverReadyResolve = undefined;
         this.isStarting = false;
-        this.actualPort = this.port; // Reset to default port
+        this.actualPort = this.port;
 
-        // Cleanup listener
         if (this.taskEndListener) {
           this.taskEndListener.dispose();
           this.taskEndListener = undefined;
         }
 
-        // Notify callback that server stopped
         if (this.onStopCallback) {
           this.onStopCallback();
         }
       }
     });
 
-    // Execute the task
     this.taskExecution = await vscode.tasks.executeTask(task);
-    this.isStarting = false; // Clear starting flag once task is executing
+    this.isStarting = false;
 
-    // Poll server URL until it responds (more reliable than timeout)
+    // Poll until the server responds
     try {
-      // Wait for Julia environment setup and Pluto installation before polling
-      // This gives time for Pkg.activate, Pkg.add, and Pkg.instantiate to complete
-      await new Promise((r) => setTimeout(r, 15000)); // Initial wait before polling
+      await new Promise((r) => setTimeout(r, 15000));
       await this.pollServerReady();
       if (this.serverReadyResolve) {
         this.serverReadyResolve();
       }
     } catch (error) {
-      // Server didn't become ready in time
       this.taskExecution.terminate();
       this.taskExecution = undefined;
       this.isStarting = false;
 
-      // Cleanup listener
       if (isDefined(this.taskEndListener)) {
         this.taskEndListener.dispose();
         this.taskEndListener = undefined;
@@ -510,18 +249,16 @@ end`
    * Poll server URL until it responds
    */
   private async pollServerReady(): Promise<void> {
-    const maxAttempts = 60; // 60 seconds total (60 attempts * 1 second)
-    const pollInterval = 1000; // 1 second between attempts
+    const maxAttempts = 60;
+    const pollInterval = 1000;
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       try {
-        // Try to fetch from server
         const response = await fetch(this.getServerUrl(), {
           method: "GET",
-          signal: AbortSignal.timeout(2000), // 2 second timeout per request
+          signal: AbortSignal.timeout(2000),
         });
 
-        // If we get any response (even error), server is running
         if (isDefined(response)) {
           return;
         }
@@ -529,7 +266,6 @@ end`
         // Server not ready yet, continue polling
       }
 
-      // Wait before next attempt
       await new Promise((resolve) => setTimeout(resolve, pollInterval));
     }
 
@@ -544,10 +280,7 @@ end`
       return;
     }
 
-    // Terminate the task (this will trigger the onDidEndTaskProcess listener)
     this.taskExecution.terminate();
-    // Note: State reset happens in the listener
-    // Reset actual port to default port when stopped
     this.actualPort = this.port;
   }
 


### PR DESCRIPTION
## Summary

- Add `julialang.language-julia` as an `extensionDependency`, guaranteeing Julia is installed and the extension API is available before our extension activates
- Introduce `src/julia-utils.ts` — a thin wrapper around the Julia extension's public API for executable discovery, package server config, and optional JuliaHub auth token retrieval
- Replace the old startup sequence in `PlutoServerTaskManager` with a single unified Julia process that runs setup (`Pkg.activate`, `Pkg.add`, `Pkg.instantiate`, `Pkg.precompile`) and then launches `Pluto.run()` in the same session

## What changed

**Before:**
- Julia executable was hardcoded to `julia` / `julia.executablePath`, ignoring active juliaup channels
- `juliaup add <version>` ran as a separate VSCode task subprocess
- JuliaHub auth used a fragile `jh auth env` tmp-file hack with a fixed 10s timeout
- Pluto setup ran as a separate blocking task, then the server launched as a second task

**After:**
- Julia executable and channel args come from `getJuliaExecutable()` via the Julia extension API (respects the user's active channel, e.g. `1.12`)
- Package server URL comes from `getPkgServer()` via the Julia extension API
- JuliaHub token comes from `JuliaComputing.juliahub-vscode-auth` if installed (gracefully skipped if not)
- Setup and 