### PR TITLE
feat: add @plutojl/cli command-line tool for Pluto notebooks

### DIFF
--- a/.github/workflows/mcp-ci.yml
+++ b/.github/workflows/mcp-ci.yml
@@ -1,0 +1,60 @@
+name: MCP CLI CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "src/cli/**"
+      - "src/plutoManagerTypes.ts"
+      - "src/plutoManager.ts"
+      - "src/mcp-server-http.ts"
+      - "src/portUtils.ts"
+      - "src/platformUtils.ts"
+      - "src/helpers.ts"
+      - "packages/advanced-pluto-mcp/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/cli/**"
+      - "src/plutoManagerTypes.ts"
+      - "src/plutoManager.ts"
+      - "src/mcp-server-http.ts"
+      - "src/portUtils.ts"
+      - "src/platformUtils.ts"
+      - "src/helpers.ts"
+      - "packages/advanced-pluto-mcp/**"
+  workflow_call: {}
+
+jobs:
+  build-mcp:
+    name: Build MCP CLI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check CLI sources
+        run: npm run check-types --workspace=packages/advanced-pluto-mcp
+
+      - name: Build CLI bundle
+        run: npm run build:production --workspace=packages/advanced-pluto-mcp
+
+      - name: Verify shebang and executable
+        run: |
+          head -1 packages/advanced-pluto-mcp/dist/cli.cjs | grep -q "#!/usr/bin/env node"
+          test -x packages/advanced-pluto-mcp/dist/cli.cjs
+          echo "CLI binary looks good"
+
+      - name: Smoke test
+        run: node packages/advanced-pluto-mcp/dist/cli.cjs --help || true

--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -1,0 +1,71 @@
+name: MCP CLI Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/cli/**"
+      - "src/plutoManagerTypes.ts"
+      - "src/plutoManager.ts"
+      - "src/mcp-server-http.ts"
+      - "packages/advanced-pluto-mcp/**"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run in dry-run mode"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: semantic-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  mcp-ci:
+    name: Run MCP CI
+    uses: ./.github/workflows/mcp-ci.yml
+
+  mcp-release:
+    name: MCP Semantic Release
+    runs-on: ubuntu-latest
+    needs: mcp-ci
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build CLI production bundle
+        run: npm run build:production --workspace=packages/advanced-pluto-mcp
+
+      - name: Run semantic-release for MCP CLI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            npx semantic-release --extends ./packages/advanced-pluto-mcp/.releaserc.json --dry-run
+          else
+            npx semantic-release --extends ./packages/advanced-pluto-mcp/.releaserc.json
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: semantic-release
+  cancel-in-progress: false
+
 permissions:
   contents: write # Required for creating releases and pushing commits
   issues: write # Required for commenting on issues

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,3 +12,4 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 **/.vscode-test.*
+packages/**

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ MCP HTTP Server  ───┘
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed version history.
 
+## Dev TODO
+
+- **VSCode notebook view does not reflect structural changes from MCP tools**: When cells are moved, deleted, or added via the MCP server (or any external client), the Pluto Worker's internal state updates automatically, but the VSCode notebook UI does not yet sync these changes. The `_handleCellReorder` handler in the controller is stubbed out. This only affects the VSCode view — the standalone MCP server and Pluto's own UI stay fully in sync.
+
 ## Support
 
 For issues, questions, or contributions, please visit the project repository on github.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See [CHANGELOG.md](CHANGELOG.md) for detailed version history.
 
 ## Dev TODO
 
-- **VSCode notebook view does not reflect structural changes from MCP tools**: When cells are moved, deleted, or added via the MCP server (or any external client), the Pluto Worker's internal state updates automatically, but the VSCode notebook UI does not yet sync these changes. The `_handleCellReorder` handler in the controller is stubbed out. This only affects the VSCode view — the standalone MCP server and Pluto's own UI stay fully in sync.
+- **VSCode notebook view does not reflect structural changes from MCP tools**: When cells are moved, deleted, or added via the MCP server (or any external client), the Pluto Worker's internal state updates automatically, but the VSCode notebook UI does not yet sync these changes. The `_handleCellReorder` handler in the controller is stubbed out. This only affects the VSCode view — external clients (the `@plutojl/cli` tool server) and Pluto's own UI stay fully in sync.
 
 ## Support
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3304,7 +3304,7 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
-    "node_modules/@plutojl/mcp": {
+    "node_modules/@plutojl/cli": {
       "resolved": "packages/advanced-pluto-mcp",
       "link": true
     },
@@ -20709,8 +20709,8 @@
       }
     },
     "packages/advanced-pluto-mcp": {
-      "name": "@plutojl/mcp",
-      "version": "0.5.0",
+      "name": "@plutojl/cli",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",
@@ -20721,7 +20721,7 @@
         "zod": "^3.25.76"
       },
       "bin": {
-        "plutojl-mcp": "dist/cli.cjs"
+        "plutojl-cli": "dist/cli.cjs"
       },
       "devDependencies": {
         "esbuild": "^0.25.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
   "name": "advanced-vscode-extension",
-  "version": "0.2.4",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "advanced-vscode-extension",
-      "version": "0.2.4",
+      "version": "0.2.7",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",
         "@plutojl/rainbow": "^0.6.19",
@@ -5558,6 +5561,10 @@
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/advanced-pluto-mcp": {
+      "resolved": "packages/advanced-pluto-mcp",
+      "link": true
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -20690,6 +20697,28 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
+      }
+    },
+    "packages/advanced-pluto-mcp": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.19.1",
+        "@plutojl/rainbow": "^0.6.19",
+        "express": "^5.1.0",
+        "uuid": "^13.0.0",
+        "ws": "^8.18.3",
+        "zod": "^3.25.76"
+      },
+      "bin": {
+        "advanced-pluto-mcp": "dist/cli.cjs"
+      },
+      "devDependencies": {
+        "esbuild": "^0.25.9",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20710,7 +20710,7 @@
     },
     "packages/advanced-pluto-mcp": {
       "name": "@plutojl/cli",
-      "version": "0.5.1",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20701,7 +20701,7 @@
     },
     "packages/advanced-pluto-mcp": {
       "name": "@plutojl/mcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",
-        "@plutojl/rainbow": "^0.6.19",
+        "@plutojl/rainbow": "^0.6.21",
         "uuid": "^13.0.0",
         "ws": "^8.18.3",
         "zod": "^3.25.76"
@@ -902,9 +902,9 @@
       }
     },
     "node_modules/@commitlint/config-validator/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1943,9 +1943,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1954,9 +1954,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2024,9 +2024,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2045,9 +2045,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2058,9 +2058,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2105,6 +2105,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
+      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2159,28 +2171,11 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "license": "ISC"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -2739,27 +2734,66 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.19.1.tgz",
-      "integrity": "sha512-3Y2h3MZKjec1eAqSTBclATlX+AbC6n1LgfVzRMJLt3v6w0RCYgwLrjbxPDbhsYHt6Wdqc/aCceNJYgj448ELQQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.6",
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -3275,11 +3309,12 @@
       "link": true
     },
     "node_modules/@plutojl/rainbow": {
-      "version": "0.6.19",
-      "resolved": "https://registry.npmjs.org/@plutojl/rainbow/-/rainbow-0.6.19.tgz",
-      "integrity": "sha512-Yb1Orcg9VCYIiwyD9GKEPUdcRZEYprRpXqoRW2CIRLjjYoNTuutjGWOyAIAM6kc+t5m7h2pkkW8RvF27Xbb/Ng==",
+      "version": "0.6.21",
+      "resolved": "https://registry.npmjs.org/@plutojl/rainbow/-/rainbow-0.6.21.tgz",
+      "integrity": "sha512-eF1buE5/8U12zhsE/SzPaAPq5bhjow0Y9ZJC2JVfPjlhakKfWGVvylOAlfkUY/clNpvShPjPzcZw0rnLcsmUyw==",
       "license": "MIT",
       "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "@observablehq/stdlib": "^3.3.1",
         "immer": "^10.1.3",
         "linkedom": "^0.18.12",
@@ -3386,9 +3421,9 @@
       }
     },
     "node_modules/@secretlint/config-loader/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5424,9 +5459,9 @@
       ]
     },
     "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5435,15 +5470,16 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "foreground-child": "^3.3.1",
         "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
@@ -5458,17 +5494,40 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+    "node_modules/@vscode/vsce/node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "ISC",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5501,9 +5560,9 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5591,9 +5650,10 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -5605,6 +5665,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -6004,35 +6103,43 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/boolbase": {
@@ -6056,9 +6163,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7030,9 +7137,9 @@
       "license": "Python-2.0"
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8227,9 +8334,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8274,9 +8381,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8484,18 +8591,19 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -8526,10 +8634,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -8584,6 +8695,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -8597,7 +8709,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8784,9 +8895,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -9184,9 +9295,10 @@
       "optional": true
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -9347,9 +9459,9 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9478,6 +9590,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.10",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
+      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hook-std": {
@@ -9835,6 +9956,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -11295,9 +11425,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11401,6 +11531,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11409,9 +11548,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11501,7 +11640,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -11619,13 +11765,13 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -11790,16 +11936,16 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -12006,9 +12152,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12264,13 +12410,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -12308,9 +12454,9 @@
       "optional": true
     },
     "node_modules/mocha": {
-      "version": "11.7.4",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.4.tgz",
-      "integrity": "sha512-1jYAaY8x0kAZ0XszLWu14pzsf4KV740Gld4HXkhNTXwcHx4AUEDkPzgEHg9CM5dVcW+zv036tjpsEbLraPJj4w==",
+      "version": "11.7.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12368,9 +12514,9 @@
       }
     },
     "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12650,9 +12796,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.9.4.tgz",
-      "integrity": "sha512-OnUG836FwboQIbqtefDNlyR0gTHzIfwRfE3DuiNewBvnMnWEpB0VEXwBlFVgqpNzIgYo/MHh3d2Hel/pszapAA==",
+      "version": "10.9.8",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-10.9.8.tgz",
+      "integrity": "sha512-fYwb6ODSmHkqrJQQaCxY3M2lPf/mpgC7ik0HSzzIwG5CGtabRp4bNqikatvCoT42b5INQSqudVH0R7yVmC9hVg==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -12734,24 +12880,24 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^8.0.1",
+        "@npmcli/arborist": "^8.0.5",
         "@npmcli/config": "^9.0.0",
         "@npmcli/fs": "^4.0.0",
         "@npmcli/map-workspaces": "^4.0.2",
         "@npmcli/package-json": "^6.2.0",
-        "@npmcli/promise-spawn": "^8.0.2",
+        "@npmcli/promise-spawn": "^8.0.3",
         "@npmcli/redact": "^3.2.2",
         "@npmcli/run-script": "^9.1.0",
         "@sigstore/tuf": "^3.1.1",
         "abbrev": "^3.0.1",
         "archy": "~1.0.0",
         "cacache": "^19.0.1",
-        "chalk": "^5.4.1",
-        "ci-info": "^4.2.0",
+        "chalk": "^5.6.2",
+        "ci-info": "^4.4.0",
         "cli-columns": "^4.0.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
-        "glob": "^10.4.5",
+        "glob": "^10.5.0",
         "graceful-fs": "^4.2.11",
         "hosted-git-info": "^8.1.0",
         "ini": "^5.0.0",
@@ -12759,46 +12905,46 @@
         "is-cidr": "^5.1.1",
         "json-parse-even-better-errors": "^4.0.0",
         "libnpmaccess": "^9.0.0",
-        "libnpmdiff": "^7.0.1",
-        "libnpmexec": "^9.0.1",
-        "libnpmfund": "^6.0.1",
+        "libnpmdiff": "^7.0.5",
+        "libnpmexec": "^9.0.5",
+        "libnpmfund": "^6.0.5",
         "libnpmhook": "^11.0.0",
         "libnpmorg": "^7.0.0",
-        "libnpmpack": "^8.0.1",
-        "libnpmpublish": "^10.0.1",
+        "libnpmpack": "^8.0.5",
+        "libnpmpublish": "^10.0.2",
         "libnpmsearch": "^8.0.0",
         "libnpmteam": "^7.0.0",
         "libnpmversion": "^7.0.0",
         "make-fetch-happen": "^14.0.3",
-        "minimatch": "^9.0.5",
-        "minipass": "^7.1.1",
+        "minimatch": "^9.0.9",
+        "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^11.2.0",
+        "node-gyp": "^11.5.0",
         "nopt": "^8.1.0",
-        "normalize-package-data": "^7.0.0",
+        "normalize-package-data": "^7.0.1",
         "npm-audit-report": "^6.0.0",
-        "npm-install-checks": "^7.1.1",
+        "npm-install-checks": "^7.1.2",
         "npm-package-arg": "^12.0.2",
         "npm-pick-manifest": "^10.0.0",
         "npm-profile": "^11.0.1",
         "npm-registry-fetch": "^18.0.2",
         "npm-user-validate": "^3.0.0",
-        "p-map": "^7.0.3",
+        "p-map": "^7.0.4",
         "pacote": "^19.0.1",
         "parse-conflict-json": "^4.0.0",
         "proc-log": "^5.0.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^4.1.0",
-        "semver": "^7.7.2",
+        "semver": "^7.7.4",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^12.0.0",
         "supports-color": "^9.4.0",
-        "tar": "^6.2.1",
+        "tar": "^7.5.11",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^6.0.1",
+        "validate-npm-package-name": "^6.0.2",
         "which": "^5.0.0",
         "write-file-atomic": "^6.0.0"
       },
@@ -12850,9 +12996,9 @@
       }
     },
     "node_modules/npm-run-all/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12930,9 +13076,9 @@
       }
     },
     "node_modules/npm-run-all/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -13042,7 +13188,7 @@
       }
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.1.0",
+      "version": "6.2.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -13077,12 +13223,12 @@
       }
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -13126,7 +13272,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "8.0.1",
+      "version": "8.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13161,6 +13307,7 @@
         "proggy": "^3.0.0",
         "promise-all-reject-late": "^1.0.0",
         "promise-call-limit": "^3.0.1",
+        "promise-retry": "^2.0.1",
         "read-package-json-fast": "^4.0.0",
         "semver": "^7.3.7",
         "ssri": "^12.0.0",
@@ -13272,7 +13419,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
-      "version": "20.0.0",
+      "version": "20.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13293,7 +13440,7 @@
         "promise-retry": "^2.0.1",
         "sigstore": "^3.0.0",
         "ssri": "^12.0.0",
-        "tar": "^6.1.11"
+        "tar": "^7.5.10"
       },
       "bin": {
         "pacote": "bin/index.js"
@@ -13339,7 +13486,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "8.0.2",
+      "version": "8.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13398,11 +13545,49 @@
         "node": ">=14"
       }
     },
+    "node_modules/npm/node_modules/@sigstore/bundle": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.4.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/core": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.4.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/sign": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^3.1.0",
+        "@sigstore/core": "^2.0.0",
+        "@sigstore/protobuf-specs": "^0.4.0",
+        "make-fetch-happen": "^14.0.2",
+        "proc-log": "^5.0.0",
+        "promise-retry": "^2.0.1"
+      },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -13415,6 +13600,20 @@
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.4.1",
         "tuf-js": "^3.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/verify": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^3.1.0",
+        "@sigstore/core": "^2.0.0",
+        "@sigstore/protobuf-specs": "^0.4.1"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -13439,7 +13638,7 @@
       }
     },
     "node_modules/npm/node_modules/agent-base": {
-      "version": "7.1.3",
+      "version": "7.1.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -13457,7 +13656,7 @@
       }
     },
     "node_modules/npm/node_modules/ansi-styles": {
-      "version": "6.2.1",
+      "version": "6.2.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -13469,7 +13668,7 @@
       }
     },
     "node_modules/npm/node_modules/aproba": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -13546,58 +13745,8 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/cacache/node_modules/chownr": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/tar": {
-      "version": "7.4.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/yallist": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/npm/node_modules/chalk": {
-      "version": "5.4.1",
+      "version": "5.6.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -13609,16 +13758,16 @@
       }
     },
     "node_modules/npm/node_modules/chownr": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/npm/node_modules/ci-info": {
-      "version": "4.2.0",
+      "version": "4.4.0",
       "dev": true,
       "funding": [
         {
@@ -13732,7 +13881,7 @@
       }
     },
     "node_modules/npm/node_modules/debug": {
-      "version": "4.4.1",
+      "version": "4.4.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -13749,7 +13898,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "5.2.0",
+      "version": "5.2.2",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -13795,7 +13944,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
-      "version": "3.1.2",
+      "version": "3.1.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
@@ -13807,6 +13956,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/npm/node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/npm/node_modules/foreground-child": {
@@ -13838,7 +14004,7 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "10.4.5",
+      "version": "10.5.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13969,14 +14135,10 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "9.0.5",
+      "version": "10.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
       "engines": {
         "node": ">= 12"
       }
@@ -14035,12 +14197,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/npm/node_modules/jsbn": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
       "dev": true,
@@ -14094,31 +14250,31 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "7.0.1",
+      "version": "7.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.1",
+        "@npmcli/arborist": "^8.0.5",
         "@npmcli/installed-package-contents": "^3.0.0",
         "binary-extensions": "^2.3.0",
         "diff": "^5.1.0",
         "minimatch": "^9.0.4",
         "npm-package-arg": "^12.0.0",
         "pacote": "^19.0.0",
-        "tar": "^6.2.1"
+        "tar": "^7.5.11"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "9.0.1",
+      "version": "9.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.1",
+        "@npmcli/arborist": "^8.0.5",
         "@npmcli/run-script": "^9.0.1",
         "ci-info": "^4.0.0",
         "npm-package-arg": "^12.0.0",
@@ -14134,12 +14290,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "6.0.1",
+      "version": "6.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.1"
+        "@npmcli/arborist": "^8.0.5"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -14172,12 +14328,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "8.0.1",
+      "version": "8.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.1",
+        "@npmcli/arborist": "^8.0.5",
         "@npmcli/run-script": "^9.0.1",
         "npm-package-arg": "^12.0.0",
         "pacote": "^19.0.0"
@@ -14187,7 +14343,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "10.0.1",
+      "version": "10.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14274,22 +14430,13 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.9",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -14299,10 +14446,10 @@
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "7.1.2",
+      "version": "7.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -14360,6 +14507,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
       "dev": true,
@@ -14383,6 +14536,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
@@ -14408,8 +14567,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/minipass-sized/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
     "node_modules/npm/node_modules/minizlib": {
-      "version": "3.0.2",
+      "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14418,18 +14583,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/npm/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/ms": {
@@ -14447,8 +14600,17 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/npm/node_modules/negotiator": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "11.2.0",
+      "version": "11.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14471,56 +14633,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/tar": {
-      "version": "7.4.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/npm/node_modules/nopt": {
       "version": "8.1.0",
       "dev": true,
@@ -14537,7 +14649,7 @@
       }
     },
     "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "7.0.0",
+      "version": "7.0.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -14572,7 +14684,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "7.1.1",
+      "version": "7.1.2",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -14676,7 +14788,7 @@
       }
     },
     "node_modules/npm/node_modules/p-map": {
-      "version": "7.0.3",
+      "version": "7.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14694,7 +14806,7 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "19.0.1",
+      "version": "19.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14715,7 +14827,7 @@
         "promise-retry": "^2.0.1",
         "sigstore": "^3.0.0",
         "ssri": "^12.0.0",
-        "tar": "^6.1.11"
+        "tar": "^7.5.10"
       },
       "bin": {
         "pacote": "bin/index.js"
@@ -14763,8 +14875,20 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/npm/node_modules/picomatch": {
+      "version": "4.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
+      "version": "7.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14896,7 +15020,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.7.2",
+      "version": "7.7.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14957,58 +15081,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/bundle": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.4.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/core": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/sign": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.0",
-        "make-fetch-happen": "^14.0.2",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/verify": {
-      "version": "2.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
       "dev": true,
@@ -15020,12 +15092,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.5",
+      "version": "2.8.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -15084,16 +15156,10 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.21",
+      "version": "3.0.23",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/npm/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "12.0.0",
@@ -15174,78 +15240,19 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.2.1",
+      "version": "7.5.11",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/minizlib": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
     "node_modules/npm/node_modules/text-table": {
@@ -15261,45 +15268,19 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/npm/node_modules/treeverse": {
@@ -15312,14 +15293,14 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "3.0.1",
+      "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@tufjs/models": "3.0.1",
-        "debug": "^4.3.6",
-        "make-fetch-happen": "^14.0.1"
+        "debug": "^4.4.1",
+        "make-fetch-happen": "^14.0.3"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -15389,7 +15370,7 @@
       }
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "6.0.1",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -15419,12 +15400,12 @@
       }
     },
     "node_modules/npm/node_modules/which/node_modules/isexe": {
-      "version": "3.1.1",
+      "version": "3.1.5",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/npm/node_modules/wrap-ansi": {
@@ -15478,7 +15459,7 @@
       }
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.1.0",
+      "version": "6.2.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -15513,12 +15494,12 @@
       }
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -15541,10 +15522,13 @@
       }
     },
     "node_modules/npm/node_modules/yallist": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -16153,9 +16137,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -16190,9 +16174,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16591,6 +16575,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16624,9 +16609,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -16746,9 +16731,9 @@
       "license": "Python-2.0"
     },
     "node_modules/rc-config-loader/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17033,7 +17018,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17533,6 +17517,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/semantic-release-vsce/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/semantic-release-vsce/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/semantic-release-vsce/node_modules/execa": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
@@ -17578,15 +17585,16 @@
       }
     },
     "node_modules/semantic-release-vsce/node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "foreground-child": "^3.3.1",
         "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
@@ -17664,16 +17672,16 @@
       }
     },
     "node_modules/semantic-release-vsce/node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -19032,9 +19040,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19244,9 +19252,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19277,9 +19285,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -19425,9 +19433,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19874,16 +19882,16 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
-      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20032,6 +20040,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -20691,17 +20700,17 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25.28 || ^4"
       }
     },
     "packages/advanced-pluto-mcp": {
       "name": "@plutojl/mcp",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3270,6 +3270,10 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@plutojl/mcp": {
+      "resolved": "packages/advanced-pluto-mcp",
+      "link": true
+    },
     "node_modules/@plutojl/rainbow": {
       "version": "0.6.19",
       "resolved": "https://registry.npmjs.org/@plutojl/rainbow/-/rainbow-0.6.19.tgz",
@@ -5561,10 +5565,6 @@
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
-    },
-    "node_modules/advanced-pluto-mcp": {
-      "resolved": "packages/advanced-pluto-mcp",
-      "link": true
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -20700,6 +20700,7 @@
       }
     },
     "packages/advanced-pluto-mcp": {
+      "name": "@plutojl/mcp",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -20711,7 +20712,7 @@
         "zod": "^3.25.76"
       },
       "bin": {
-        "advanced-pluto-mcp": "dist/cli.cjs"
+        "plutojl-mcp": "dist/cli.cjs"
       },
       "devDependencies": {
         "esbuild": "^0.25.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20701,7 +20701,7 @@
     },
     "packages/advanced-pluto-mcp": {
       "name": "@plutojl/mcp",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",

--- a/package.json
+++ b/package.json
@@ -282,7 +282,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.19.1",
-    "@plutojl/rainbow": "^0.6.19",
+    "@plutojl/rainbow": "^0.6.21",
     "uuid": "^13.0.0",
     "ws": "^8.18.3",
     "zod": "^3.25.76"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "baseImagesUrl": "https://github.com/JuliaPluto/advanced-vscode-extension/raw/main/"
   },
   "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
   "engines": {
     "vscode": "^1.75.0"
   },

--- a/packages/advanced-pluto-mcp/.gitignore
+++ b/packages/advanced-pluto-mcp/.gitignore
@@ -1,0 +1,3 @@
+dist/
+out/
+node_modules/

--- a/packages/advanced-pluto-mcp/.releaserc.json
+++ b/packages/advanced-pluto-mcp/.releaserc.json
@@ -1,0 +1,42 @@
+{
+  "branches": ["main"],
+  "tagFormat": "mcp-v${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "packages/advanced-pluto-mcp/CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": true,
+        "pkgRoot": "packages/advanced-pluto-mcp"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          {
+            "path": "packages/advanced-pluto-mcp/CHANGELOG.md",
+            "label": "MCP CLI Changelog"
+          }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "packages/advanced-pluto-mcp/package.json",
+          "packages/advanced-pluto-mcp/CHANGELOG.md"
+        ],
+        "message": "chore(mcp-release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ]
+  ]
+}

--- a/packages/advanced-pluto-mcp/README.md
+++ b/packages/advanced-pluto-mcp/README.md
@@ -1,4 +1,4 @@
-# @plutojl/mcp
+# @plutojl/cli
 
 Standalone MCP (Model Context Protocol) server for [Pluto.jl](https://plutojl.org/) notebooks. Enables AI assistants like Claude and GitHub Copilot to interact with Julia Pluto notebooks.
 
@@ -6,10 +6,10 @@ Standalone MCP (Model Context Protocol) server for [Pluto.jl](https://plutojl.or
 
 ```bash
 # Start the MCP server (also starts a Pluto server)
-npx @plutojl/mcp run
+npx @plutojl/cli run
 
 # Install MCP config for Claude Code
-npx @plutojl/mcp install
+npx @plutojl/cli install
 ```
 
 ## Prerequisites
@@ -25,7 +25,7 @@ npx @plutojl/mcp install
 Start the MCP server (and a Pluto server if needed).
 
 ```bash
-npx @plutojl/mcp run [options]
+npx @plutojl/cli run [options]
 ```
 
 | Option                  | Default  | Description                                          |
@@ -40,7 +40,7 @@ npx @plutojl/mcp run [options]
 Add MCP configuration files for AI assistants.
 
 ```bash
-npx @plutojl/mcp install [options]
+npx @plutojl/cli install [options]
 ```
 
 | Option              | Default       | Description                                       |

--- a/packages/advanced-pluto-mcp/README.md
+++ b/packages/advanced-pluto-mcp/README.md
@@ -1,0 +1,97 @@
+# advanced-pluto-mcp
+
+Standalone MCP (Model Context Protocol) server for [Pluto.jl](https://plutojl.org/) notebooks. Enables AI assistants like Claude and GitHub Copilot to interact with Julia Pluto notebooks.
+
+## Quick Start
+
+```bash
+# Start the MCP server (also starts a Pluto server)
+npx advanced-pluto-mcp run
+
+# Install MCP config for Claude Code
+npx advanced-pluto-mcp install
+```
+
+## Prerequisites
+
+- **Node.js** >= 18
+- **Julia** — install from [julialang.org](https://julialang.org/downloads/) or via [juliaup](https://github.com/JuliaLang/juliaup)
+- **Pluto.jl** — installed automatically on first run
+
+## Commands
+
+### `run`
+
+Start the MCP server (and a Pluto server if needed).
+
+```bash
+npx advanced-pluto-mcp run [options]
+```
+
+| Option                  | Default  | Description                                          |
+| ----------------------- | -------- | ---------------------------------------------------- |
+| `--mcp-port <port>`     | `3100`   | MCP server port                                      |
+| `--pluto-port <port>`   | `1234`   | Pluto server port                                    |
+| `--pluto-url <url>`     | —        | Connect to existing Pluto server (skip starting one) |
+| `--julia-version <ver>` | `1.11.7` | Julia version via juliaup                            |
+
+### `install`
+
+Add MCP configuration files for AI assistants.
+
+```bash
+npx advanced-pluto-mcp install [options]
+```
+
+| Option              | Default       | Description                                       |
+| ------------------- | ------------- | ------------------------------------------------- |
+| `--target <target>` | `claude-code` | Config target: `claude-code`, `copilot`, or `all` |
+| `--mcp-port <port>` | `3100`        | MCP server port to configure                      |
+| `--global`          | —             | Write to `~/.claude/` instead of `./.claude/`     |
+| `--dry-run`         | —             | Print config without writing                      |
+| `--force`           | —             | Overwrite existing config                         |
+
+## Configuration
+
+Configuration is resolved in priority order:
+
+1. CLI arguments
+2. Environment variables (`PLUTO_MCP_PORT`, `PLUTO_PORT`, `PLUTO_SERVER_URL`, `JULIA_VERSION`)
+3. `.plutomcp.json` in current directory
+4. Defaults
+
+Example `.plutomcp.json`:
+
+```json
+{
+  "mcpPort": 3100,
+  "plutoPort": 1234,
+  "juliaVersion": "1.11.7"
+}
+```
+
+## MCP Tools
+
+The server exposes these tools to AI assistants:
+
+| Tool                      | Description                        |
+| ------------------------- | ---------------------------------- |
+| `learn_pluto_basics`      | Get a comprehensive Pluto.jl guide |
+| `start_pluto_server`      | Start the Pluto server             |
+| `stop_pluto_server`       | Stop the Pluto server              |
+| `connect_to_pluto_server` | Connect to an existing server      |
+| `get_notebook_status`     | Check server status                |
+| `open_notebook`           | Open a notebook file               |
+| `list_notebooks`          | List all open notebooks            |
+| `create_cell`             | Create and execute a new cell      |
+| `read_cell`               | Read cell code and output          |
+| `edit_cell`               | Update cell code                   |
+| `execute_cell`            | Run an existing cell               |
+| `execute_code`            | Execute code ephemerally           |
+| `get_docs`                | Get Julia symbol documentation     |
+| `introspect_notebook`     | List all symbols in a notebook     |
+
+## Related
+
+- [Advanced Pluto Notebook for VSCode](https://marketplace.visualstudio.com/items?itemName=juliapluto-pankgeorg.advanced-vscode-extension) — VSCode extension with full notebook UI
+- [Pluto.jl](https://plutojl.org/) — Reactive Julia notebooks

--- a/packages/advanced-pluto-mcp/README.md
+++ b/packages/advanced-pluto-mcp/README.md
@@ -1,14 +1,19 @@
 # @plutojl/cli
 
-Standalone MCP (Model Context Protocol) server for [Pluto.jl](https://plutojl.org/) notebooks. Enables AI assistants like Claude and GitHub Copilot to interact with Julia Pluto notebooks.
+Command-line tool for [Pluto.jl](https://plutojl.org/) notebooks. Start a Pluto server and drive notebooks straight from your terminal — open notebooks, create and execute cells, read outputs. The tool server it starts also speaks MCP (Model Context Protocol), so AI assistants like Claude and GitHub Copilot can use the same tools.
 
 ## Quick Start
 
 ```bash
-# Start the MCP server (also starts a Pluto server)
+# Start Pluto and the tool server
 npx @plutojl/cli run
 
-# Install MCP config for Claude Code
+# In another terminal: drive notebooks from the command line
+npx @plutojl/cli tools
+npx @plutojl/cli call open_notebook '{"path": "notebook.pluto.jl"}'
+npx @plutojl/cli call execute_code '{"code": "1 + 1"}'
+
+# Optional: install MCP config so AI assistants can connect too
 npx @plutojl/cli install
 ```
 
@@ -22,7 +27,7 @@ npx @plutojl/cli install
 
 ### `run`
 
-Start the MCP server (and a Pluto server if needed).
+Start Pluto and the tool server.
 
 ```bash
 npx @plutojl/cli run [options]
@@ -30,26 +35,53 @@ npx @plutojl/cli run [options]
 
 | Option                  | Default  | Description                                          |
 | ----------------------- | -------- | ---------------------------------------------------- |
-| `--mcp-port <port>`     | `3100`   | MCP server port                                      |
+| `--mcp-port <port>`     | `3100`   | Tool server (MCP) port                               |
 | `--pluto-port <port>`   | `1234`   | Pluto server port                                    |
 | `--pluto-url <url>`     | —        | Connect to existing Pluto server (skip starting one) |
 | `--julia-version <ver>` | `1.11.7` | Julia version via juliaup                            |
+| `--no-pluto`            | —        | Start the tool server only, without starting Pluto   |
+
+### `tools`
+
+List the notebook tools available on a running server.
+
+```bash
+npx @plutojl/cli tools [--mcp-port <port>]
+```
+
+### `call`
+
+Call a notebook tool from the command line.
+
+```bash
+npx @plutojl/cli call <tool_name> [json_args] [options]
+
+# Examples
+npx @plutojl/cli call get_notebook_status
+npx @plutojl/cli call open_notebook '{"path": "/tmp/nb.pluto.jl"}'
+npx @plutojl/cli call execute_code '{"code": "sqrt(2)"}'
+```
+
+| Option              | Default | Description             |
+| ------------------- | ------- | ----------------------- |
+| `--mcp-port <port>` | `3100`  | Tool server (MCP) port  |
+| `--raw`             | —       | Output raw JSON response|
 
 ### `install`
 
-Add MCP configuration files for AI assistants.
+Add MCP configuration files so AI assistants can connect to the tool server.
 
 ```bash
 npx @plutojl/cli install [options]
 ```
 
-| Option              | Default       | Description                                       |
-| ------------------- | ------------- | ------------------------------------------------- |
-| `--target <target>` | `claude-code` | Config target: `claude-code`, `copilot`, or `all` |
-| `--mcp-port <port>` | `3100`        | MCP server port to configure                      |
-| `--global`          | —             | Write to `~/.claude/` instead of `./.claude/`     |
-| `--dry-run`         | —             | Print config without writing                      |
-| `--force`           | —             | Overwrite existing config                         |
+| Option              | Default       | Description                                          |
+| ------------------- | ------------- | ---------------------------------------------------- |
+| `--target <target>` | `claude-code` | Config target: `claude-code`, `copilot`, or `all`    |
+| `--mcp-port <port>` | `3100`        | Tool server (MCP) port to configure                  |
+| `--global`          | —             | Write to `~/.claude.json` instead of `./.mcp.json`   |
+| `--dry-run`         | —             | Print config without writing                         |
+| `--force`           | —             | Overwrite existing config                            |
 
 ## Configuration
 
@@ -70,9 +102,9 @@ Example `.plutomcp.json`:
 }
 ```
 
-## MCP Tools
+## Notebook tools
 
-The server exposes these tools to AI assistants:
+These tools are callable from the command line via `call`, and exposed to AI assistants over MCP:
 
 | Tool                      | Description                        |
 | ------------------------- | ---------------------------------- |

--- a/packages/advanced-pluto-mcp/README.md
+++ b/packages/advanced-pluto-mcp/README.md
@@ -62,10 +62,10 @@ npx @plutojl/cli call open_notebook '{"path": "/tmp/nb.pluto.jl"}'
 npx @plutojl/cli call execute_code '{"code": "sqrt(2)"}'
 ```
 
-| Option              | Default | Description             |
-| ------------------- | ------- | ----------------------- |
-| `--mcp-port <port>` | `3100`  | Tool server (MCP) port  |
-| `--raw`             | —       | Output raw JSON response|
+| Option              | Default | Description              |
+| ------------------- | ------- | ------------------------ |
+| `--mcp-port <port>` | `3100`  | Tool server (MCP) port   |
+| `--raw`             | —       | Output raw JSON response |
 
 ### `install`
 
@@ -75,13 +75,13 @@ Add MCP configuration files so AI assistants can connect to the tool server.
 npx @plutojl/cli install [options]
 ```
 
-| Option              | Default       | Description                                          |
-| ------------------- | ------------- | ---------------------------------------------------- |
-| `--target <target>` | `claude-code` | Config target: `claude-code`, `copilot`, or `all`    |
-| `--mcp-port <port>` | `3100`        | Tool server (MCP) port to configure                  |
-| `--global`          | —             | Write to `~/.claude.json` instead of `./.mcp.json`   |
-| `--dry-run`         | —             | Print config without writing                         |
-| `--force`           | —             | Overwrite existing config                            |
+| Option              | Default       | Description                                        |
+| ------------------- | ------------- | -------------------------------------------------- |
+| `--target <target>` | `claude-code` | Config target: `claude-code`, `copilot`, or `all`  |
+| `--mcp-port <port>` | `3100`        | Tool server (MCP) port to configure                |
+| `--global`          | —             | Write to `~/.claude.json` instead of `./.mcp.json` |
+| `--dry-run`         | —             | Print config without writing                       |
+| `--force`           | —             | Overwrite existing config                          |
 
 ## Configuration
 

--- a/packages/advanced-pluto-mcp/README.md
+++ b/packages/advanced-pluto-mcp/README.md
@@ -106,22 +106,29 @@ Example `.plutomcp.json`:
 
 These tools are callable from the command line via `call`, and exposed to AI assistants over MCP:
 
-| Tool                      | Description                        |
-| ------------------------- | ---------------------------------- |
-| `learn_pluto_basics`      | Get a comprehensive Pluto.jl guide |
-| `start_pluto_server`      | Start the Pluto server             |
-| `stop_pluto_server`       | Stop the Pluto server              |
-| `connect_to_pluto_server` | Connect to an existing server      |
-| `get_notebook_status`     | Check server status                |
-| `open_notebook`           | Open a notebook file               |
-| `list_notebooks`          | List all open notebooks            |
-| `create_cell`             | Create and execute a new cell      |
-| `read_cell`               | Read cell code and output          |
-| `edit_cell`               | Update cell code                   |
-| `execute_cell`            | Run an existing cell               |
-| `execute_code`            | Execute code ephemerally           |
-| `get_docs`                | Get Julia symbol documentation     |
-| `introspect_notebook`     | List all symbols in a notebook     |
+| Tool                      | Description                                |
+| ------------------------- | ------------------------------------------ |
+| `learn_pluto_basics`      | Get a comprehensive Pluto.jl guide         |
+| `start_pluto_server`      | Start the Pluto server                     |
+| `stop_pluto_server`       | Stop the Pluto server                      |
+| `connect_to_pluto_server` | Connect to an existing server              |
+| `get_notebook_status`     | Check server status                        |
+| `open_notebook`           | Open a notebook file                       |
+| `move_notebook`           | Move a notebook to a new path              |
+| `save_notebook`           | Save the running notebook to disk          |
+| `list_notebooks`          | List all open notebooks                    |
+| `get_notebook_url`        | Get the Pluto web UI URL for a notebook    |
+| `list_cells`              | List cells with IDs and execution status   |
+| `create_cell`             | Create and execute a new cell              |
+| `read_cell`               | Read cell code and output                  |
+| `edit_cell`               | Update cell code                           |
+| `execute_cell`            | Run an existing cell                       |
+| `delete_cell`             | Remove a cell                              |
+| `move_cells`              | Reorder cells                              |
+| `fold_cell`               | Show or hide a cell's code in the Pluto UI |
+| `execute_code`            | Execute code ephemerally (no cell created) |
+| `get_docs`                | Get Julia symbol documentation             |
+| `introspect_notebook`     | List all symbols defined in a notebook     |
 
 ## Related
 

--- a/packages/advanced-pluto-mcp/README.md
+++ b/packages/advanced-pluto-mcp/README.md
@@ -1,4 +1,4 @@
-# advanced-pluto-mcp
+# @plutojl/mcp
 
 Standalone MCP (Model Context Protocol) server for [Pluto.jl](https://plutojl.org/) notebooks. Enables AI assistants like Claude and GitHub Copilot to interact with Julia Pluto notebooks.
 
@@ -6,10 +6,10 @@ Standalone MCP (Model Context Protocol) server for [Pluto.jl](https://plutojl.or
 
 ```bash
 # Start the MCP server (also starts a Pluto server)
-npx advanced-pluto-mcp run
+npx @plutojl/mcp run
 
 # Install MCP config for Claude Code
-npx advanced-pluto-mcp install
+npx @plutojl/mcp install
 ```
 
 ## Prerequisites
@@ -25,7 +25,7 @@ npx advanced-pluto-mcp install
 Start the MCP server (and a Pluto server if needed).
 
 ```bash
-npx advanced-pluto-mcp run [options]
+npx @plutojl/mcp run [options]
 ```
 
 | Option                  | Default  | Description                                          |
@@ -40,7 +40,7 @@ npx advanced-pluto-mcp run [options]
 Add MCP configuration files for AI assistants.
 
 ```bash
-npx advanced-pluto-mcp install [options]
+npx @plutojl/mcp install [options]
 ```
 
 | Option              | Default       | Description                                       |

--- a/packages/advanced-pluto-mcp/esbuild.mjs
+++ b/packages/advanced-pluto-mcp/esbuild.mjs
@@ -1,0 +1,54 @@
+import esbuild from "esbuild";
+import { chmodSync, mkdirSync } from "fs";
+import { fileURLToPath } from "url";
+import { join, dirname } from "path";
+
+const production = process.argv.includes("--production");
+const watch = process.argv.includes("--watch");
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function main() {
+  mkdirSync("dist", { recursive: true });
+
+  const ctx = await esbuild.context({
+    entryPoints: [join(__dirname, "../../src/cli/index.ts")],
+    bundle: true,
+    format: "cjs",
+    platform: "node",
+    target: "node18",
+    outfile: "dist/cli.cjs",
+    banner: {
+      js: "#!/usr/bin/env node",
+    },
+    minify: production,
+    sourcemap: !production,
+    sourcesContent: false,
+    // vscode must never be bundled — fail loudly if it leaks
+    external: ["vscode"],
+    // Ensure esbuild can resolve modules from root node_modules
+    nodePaths: [join(__dirname, "../../node_modules")],
+    loader: {
+      ".md": "text",
+    },
+    logLevel: "info",
+  });
+
+  if (watch) {
+    console.log("[cli-watch] watching for changes...");
+    await ctx.watch();
+  } else {
+    await ctx.rebuild();
+    await ctx.dispose();
+    // Make the output executable
+    try {
+      chmodSync("dist/cli.cjs", 0o755);
+    } catch {
+      // chmod not available on Windows; npm bin handles it
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/advanced-pluto-mcp/package.json
+++ b/packages/advanced-pluto-mcp/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "advanced-pluto-mcp",
+  "version": "0.1.0",
+  "description": "Standalone MCP server for Pluto.jl notebooks — run with npx advanced-pluto-mcp",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JuliaPluto/advanced-vscode-extension",
+    "directory": "packages/advanced-pluto-mcp"
+  },
+  "type": "module",
+  "bin": {
+    "advanced-pluto-mcp": "./dist/cli.cjs"
+  },
+  "files": [
+    "dist/cli.cjs",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "build": "node esbuild.mjs",
+    "build:production": "node esbuild.mjs --production",
+    "watch": "node esbuild.mjs --watch",
+    "check-types": "tsc --project tsconfig.json",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.19.1",
+    "@plutojl/rainbow": "^0.6.19",
+    "express": "^5.1.0",
+    "uuid": "^13.0.0",
+    "ws": "^8.18.3",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.9",
+    "typescript": "^5.9.2"
+  }
+}

--- a/packages/advanced-pluto-mcp/package.json
+++ b/packages/advanced-pluto-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plutojl/cli",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Standalone MCP server for Pluto.jl notebooks — run with npx @plutojl/cli",
   "license": "MIT",
   "repository": {

--- a/packages/advanced-pluto-mcp/package.json
+++ b/packages/advanced-pluto-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plutojl/cli",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Standalone MCP server for Pluto.jl notebooks — run with npx @plutojl/cli",
   "license": "MIT",
   "repository": {

--- a/packages/advanced-pluto-mcp/package.json
+++ b/packages/advanced-pluto-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@plutojl/cli",
   "version": "0.5.5",
-  "description": "Standalone MCP server for Pluto.jl notebooks — run with npx @plutojl/cli",
+  "description": "Command-line tool for Pluto.jl notebooks — start a Pluto server and drive notebooks from your terminal; also serves MCP for AI assistants. Run with npx @plutojl/cli",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/advanced-pluto-mcp/package.json
+++ b/packages/advanced-pluto-mcp/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "advanced-pluto-mcp",
+  "name": "@plutojl/mcp",
   "version": "0.1.0",
-  "description": "Standalone MCP server for Pluto.jl notebooks — run with npx advanced-pluto-mcp",
+  "description": "Standalone MCP server for Pluto.jl notebooks — run with npx @plutojl/mcp",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "bin": {
-    "advanced-pluto-mcp": "./dist/cli.cjs"
+    "plutojl-mcp": "./dist/cli.cjs"
   },
   "files": [
     "dist/cli.cjs",

--- a/packages/advanced-pluto-mcp/package.json
+++ b/packages/advanced-pluto-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plutojl/mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Standalone MCP server for Pluto.jl notebooks — run with npx @plutojl/mcp",
   "license": "MIT",
   "repository": {

--- a/packages/advanced-pluto-mcp/package.json
+++ b/packages/advanced-pluto-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plutojl/mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Standalone MCP server for Pluto.jl notebooks — run with npx @plutojl/mcp",
   "license": "MIT",
   "repository": {

--- a/packages/advanced-pluto-mcp/package.json
+++ b/packages/advanced-pluto-mcp/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@plutojl/mcp",
+  "name": "@plutojl/cli",
   "version": "0.5.1",
-  "description": "Standalone MCP server for Pluto.jl notebooks — run with npx @plutojl/mcp",
+  "description": "Standalone MCP server for Pluto.jl notebooks — run with npx @plutojl/cli",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "bin": {
-    "plutojl-mcp": "./dist/cli.cjs"
+    "plutojl-cli": "./dist/cli.cjs"
   },
   "files": [
     "dist/cli.cjs",

--- a/packages/advanced-pluto-mcp/package.json
+++ b/packages/advanced-pluto-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plutojl/cli",
-  "version": "0.5.2",
+  "version": "0.5.4",
   "description": "Standalone MCP server for Pluto.jl notebooks — run with npx @plutojl/cli",
   "license": "MIT",
   "repository": {

--- a/packages/advanced-pluto-mcp/package.json
+++ b/packages/advanced-pluto-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plutojl/mcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Standalone MCP server for Pluto.jl notebooks — run with npx @plutojl/mcp",
   "license": "MIT",
   "repository": {

--- a/packages/advanced-pluto-mcp/package.json
+++ b/packages/advanced-pluto-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plutojl/mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Standalone MCP server for Pluto.jl notebooks — run with npx @plutojl/mcp",
   "license": "MIT",
   "repository": {

--- a/packages/advanced-pluto-mcp/tsconfig.json
+++ b/packages/advanced-pluto-mcp/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../../src",
+    "outDir": "./out",
+    "noEmit": true
+  },
+  "include": [
+    "../../src/cli/**/*.ts",
+    "../../src/plutoManager.ts",
+    "../../src/plutoManagerTypes.ts",
+    "../../src/mcp-server-http.ts",
+    "../../src/platformUtils.ts",
+    "../../src/portUtils.ts",
+    "../../src/helpers.ts"
+  ],
+  "exclude": []
+}

--- a/src/PLUTO_GUIDE.md
+++ b/src/PLUTO_GUIDE.md
@@ -21,6 +21,7 @@ These rules are critical when interacting with Pluto notebooks through the MCP A
 - **Never edit the `.pluto.jl` file on disk while the notebook is open** — Pluto owns that file. Changes made outside the MCP API will be ignored or overwritten.
 - All cell mutations (create, edit, delete) must go through the MCP tools.
 - To persist changes to disk, call `save_notebook` explicitly. **Notebooks are NOT auto-saved.**
+- **If a change (folding, reordering, etc.) does not appear to have persisted on disk, do not attempt to fix it yourself.** Just inform the user — Pluto manages file writes and the issue may be on the server side.
 
 ### Handling Timeouts
 
@@ -32,16 +33,22 @@ These rules are critical when interacting with Pluto notebooks through the MCP A
 
 - **Each variable can only be defined in one cell.** If you get a "Multiple definitions" error, use `list_cells` to find the duplicate, then `delete_cell` to remove it.
 - When you edit a cell, Pluto automatically re-runs all cells that depend on the changed variables.
-- Prefer creating package cells with `import Pkg; Pkg.activate(; temp=true); Pkg.add([...])` in one cell, and `using PackageName` in a separate cell.
+- **Just `using PackageName`** — Pluto's built-in package manager will automatically install and track the package. Only fall back to a manual `import Pkg; Pkg.activate(; temp=true); Pkg.add([...])` cell if the plain `using` approach fails.
+
+### Cell Visibility
+
+- **Fold cells that are markdown-only or plot-only** using `fold_cell` — this hides the source code in Pluto's UI while still showing the rendered output. It keeps the notebook clean for readers.
+- Use `list_cells` to check the current `code_folded` state of each cell.
 
 ### Recommended Workflow
 
 1. `open_notebook` (file must exist on disk first)
 2. `list_cells` to see current state
 3. `create_cell` / `edit_cell` / `delete_cell` to make changes
-4. `read_cell` to inspect outputs
-5. `save_notebook` to persist to disk when done
-6. `get_notebook_url` to give the user a browser link
+4. `fold_cell` to hide code for markdown/plot cells
+5. `read_cell` to inspect outputs
+6. `save_notebook` to persist to disk when done
+7. `get_notebook_url` to give the user a browser link
 
 ## Table of Contents
 
@@ -51,6 +58,7 @@ These rules are critical when interacting with Pluto notebooks through the MCP A
 - [PlutoUI Components](#plutoui-components)
 - [Combining Markdown and PlutoUI](#combining-markdown-and-plutoui)
 - [Best Practices](#best-practices)
+- [Beautifying a Notebook](#beautifying-a-notebook)
 - [Common Patterns](#common-patterns)
 
 ---
@@ -164,13 +172,23 @@ This defines the display order of cells (not execution order).
 
 5. **Import/Package Management**
 
+   Pluto has a built-in package manager — just `using` the package you need:
+
+   ```julia
+   using Plots
+   ```
+
+   ```julia
+   using DataFrames
+   ```
+
+   Pluto will automatically install and track the package. Only fall back to the manual approach if the above fails:
+
    ```julia
    begin
        import Pkg
        Pkg.activate(; temp=true)
-       Pkg.add(["Plots", "DataFrames", "PlutoUI"])
-       using Plots
-       using PlutoUI
+       Pkg.add(["Plots", "DataFrames"])
    end
    ```
 
@@ -243,17 +261,15 @@ md"""
 
 ## PlutoUI Components
 
-PlutoUI provides interactive widgets using the `@bind` macro.
+PlutoUI provides interactive widgets using the `@bind` macro. **If the user asks for interactivity** (sliders, dropdowns, toggles, user input, etc.), suggest using PlutoUI — it is the standard way to add interactive controls to Pluto notebooks.
 
 ### Installation
 
 ```julia
-begin
-    import Pkg
-    Pkg.add("PlutoUI")
-    using PlutoUI
-end
+using PlutoUI
 ```
+
+Pluto's built-in package manager will install it automatically.
 
 ### @bind Macro
 
@@ -514,18 +530,17 @@ end
 
 ### 1. Package Management
 
-Always use a cell at the beginning for package management:
+Just `using` the packages you need — Pluto will install them automatically:
 
 ```julia
-begin
-    import Pkg
-    Pkg.activate(; temp=true)
-    Pkg.add(["Plots", "DataFrames", "PlutoUI"])
-    using Plots
-    using DataFrames
-    using PlutoUI
-end
+using Plots
 ```
+
+```julia
+using DataFrames
+```
+
+Each `using` should be in its own cell. Only use the manual `Pkg.activate(; temp=true)` + `Pkg.add(...)` approach as a fallback if automatic installation fails.
 
 ### 2. Organize with Markdown Headers
 
@@ -606,6 +621,92 @@ Sum: $(x + y)
 Product: $(x * y)
 """
 ```
+
+---
+
+## Beautifying a Notebook
+
+When a notebook is functionally complete, polish it for readability. Use `move_cells`, `fold_cell`, and markdown cells to turn working code into a presentable document.
+
+### Notebook Structure
+
+Aim for this top-to-bottom layout:
+
+1. **Title and introduction** — a markdown cell with the notebook title, author, and purpose
+2. **Table of Contents** — a markdown cell with `TableOfContents()` from PlutoUI
+3. **Key results and summary** — the main outputs, plots, or conclusions the reader cares about
+4. **Analysis sections** — the substantive work, organized under markdown headers
+5. **Boilerplate at the bottom** — package imports, helper functions, constants, and configuration cells
+
+Use `move_cells` to reorder cells into this layout.
+
+### Table of Contents
+
+Add a `TableOfContents` cell near the top (requires PlutoUI):
+
+```julia
+TableOfContents()
+```
+
+This renders a sticky sidebar that links to all `#`, `##`, `###` headings in your markdown cells.
+
+### Folding Cells
+
+Use `fold_cell` to hide source code while keeping the rendered output visible:
+
+- **Always fold**: markdown-only cells (the reader sees the rendered text, not the `md"""` wrapper), plot-only cells, `TableOfContents()` cells
+- **Usually fold**: helper function definitions, data loading, configuration
+- **Don't fold**: cells the reader needs to see the code for (interactive widgets with `@bind`, key computations)
+
+### Section Headers
+
+Break the notebook into logical sections with markdown headers:
+
+```julia
+md"""
+# 1. Data Loading
+"""
+```
+
+```julia
+md"""
+# 2. Analysis
+"""
+```
+
+```julia
+md"""
+# 3. Results
+"""
+```
+
+Fold these header cells so only the rendered heading shows.
+
+### Fine-Tuning Text
+
+- Use **bold** for key terms and results: `**accuracy: 94.2%**`
+- Use inline code for variable names and function references: `` `my_function` ``
+- Add context to plots with a markdown cell above or below explaining what the reader should notice
+- Use admonitions for important notes:
+
+```julia
+md"""
+!!! tip "Performance"
+    This computation runs in O(n log n) time.
+"""
+```
+
+### Checklist
+
+After finishing the notebook content, run through these steps:
+
+1. Add a title cell at the very top
+2. Add `TableOfContents()` right after the title
+3. Move results/summary cells near the top, below the TOC
+4. Move boilerplate (imports, helpers, constants) to the bottom
+5. Fold all markdown cells, plot cells, TOC, and boilerplate
+6. Ensure each section has a markdown header
+7. `save_notebook` to persist the final layout
 
 ---
 

--- a/src/PLUTO_GUIDE.md
+++ b/src/PLUTO_GUIDE.md
@@ -12,6 +12,37 @@ Starting a Pluto server involves installing Julia packages and precompiling them
 
 If a tool call times out, that does NOT mean it failed — the server may still be starting in the background. Check `get_notebook_status` before retrying.
 
+## Working with Notebooks via MCP
+
+These rules are critical when interacting with Pluto notebooks through the MCP API:
+
+### File Ownership
+
+- **Never edit the `.pluto.jl` file on disk while the notebook is open** — Pluto owns that file. Changes made outside the MCP API will be ignored or overwritten.
+- All cell mutations (create, edit, delete) must go through the MCP tools.
+- To persist changes to disk, call `save_notebook` explicitly. **Notebooks are NOT auto-saved.**
+
+### Handling Timeouts
+
+- If `create_cell` times out, the cell was likely still created in Pluto. Use `list_cells` to check before retrying — creating the same cell twice causes "Multiple definitions" errors.
+- For slow operations (e.g. `import Pkg; Pkg.add(...)`), prefer: (1) `edit_cell` with `run=false` to set the code, then (2) `execute_cell` to run it. This avoids timeout-induced phantom cells.
+- Use `delete_cell` to remove any accidental duplicate cells.
+
+### Pluto Reactivity Rules
+
+- **Each variable can only be defined in one cell.** If you get a "Multiple definitions" error, use `list_cells` to find the duplicate, then `delete_cell` to remove it.
+- When you edit a cell, Pluto automatically re-runs all cells that depend on the changed variables.
+- Prefer creating package cells with `import Pkg; Pkg.activate(; temp=true); Pkg.add([...])` in one cell, and `using PackageName` in a separate cell.
+
+### Recommended Workflow
+
+1. `open_notebook` (file must exist on disk first)
+2. `list_cells` to see current state
+3. `create_cell` / `edit_cell` / `delete_cell` to make changes
+4. `read_cell` to inspect outputs
+5. `save_notebook` to persist to disk when done
+6. `get_notebook_url` to give the user a browser link
+
 ## Table of Contents
 
 - [Notebook Structure](#notebook-structure)

--- a/src/PLUTO_GUIDE.md
+++ b/src/PLUTO_GUIDE.md
@@ -2,6 +2,16 @@
 
 This guide explains how to work with Pluto.jl notebooks, including cell structure, reactivity rules, PlutoUI components, and best practices.
 
+## Important: Server Startup Times
+
+Starting a Pluto server involves installing Julia packages and precompiling them. **The first run can take several minutes** (2-10 minutes depending on the system). If `start_pluto_server` or `open_notebook` appears to hang or times out:
+
+1. **Do not retry immediately** — the server is likely still starting up.
+2. **Wait 30-60 seconds**, then call `get_notebook_status` to check progress.
+3. **Subsequent runs are much faster** since packages are cached.
+
+If a tool call times out, that does NOT mean it failed — the server may still be starting in the background. Check `get_notebook_status` before retrying.
+
 ## Table of Contents
 
 - [Notebook Structure](#notebook-structure)

--- a/src/PLUTO_GUIDE.md
+++ b/src/PLUTO_GUIDE.md
@@ -636,7 +636,8 @@ Aim for this top-to-bottom layout:
 2. **Table of Contents** — a markdown cell with `TableOfContents()` from PlutoUI
 3. **Key results and summary** — the main outputs, plots, or conclusions the reader cares about
 4. **Analysis sections** — the substantive work, organized under markdown headers
-5. **Boilerplate at the bottom** — package imports, helper functions, constants, and configuration cells
+5. **Boilerplate at the bottom** — helper functions, constants, and configuration cells
+6. **`Pkg` cells at the very end** — any manual `Pkg.activate` / `Pkg.add` cells should be the last cells in the notebook
 
 Use `move_cells` to reorder cells into this layout.
 
@@ -654,9 +655,11 @@ This renders a sticky sidebar that links to all `#`, `##`, `###` headings in you
 
 Use `fold_cell` to hide source code while keeping the rendered output visible:
 
-- **Always fold**: markdown-only cells (the reader sees the rendered text, not the `md"""` wrapper), plot-only cells, `TableOfContents()` cells
+Folding hides the **source code**, not the output — the rendered result is always visible.
+
+- **Always fold**: markdown cells (`md"""`, `@mdx`), `@bind` widget cells, plot-only cells, `TableOfContents()` cells
 - **Usually fold**: helper function definitions, data loading, configuration
-- **Don't fold**: cells the reader needs to see the code for (interactive widgets with `@bind`, key computations)
+- **Don't fold**: cells where the source code itself is meant to be read (tutorials, examples, key algorithms)
 
 ### Section Headers
 
@@ -696,6 +699,41 @@ md"""
 """
 ```
 
+### HTML in Markdown
+
+If you need raw HTML in markdown cells (custom styling, embedded iframes, etc.), use `MarkdownLiteral`:
+
+```julia
+using MarkdownLiteral: @mdx
+```
+
+Then use `@mdx` instead of `md`:
+
+```julia
+@mdx """
+<div style="background: #f0f0f0; padding: 1em; border-radius: 8px;">
+  <h3>Custom styled block</h3>
+  <p>This supports full HTML.</p>
+</div>
+"""
+```
+
+**Note:** You cannot combine `:` imports with comma-separated `using` — each must be its own cell:
+
+```julia
+# ✅ CORRECT — separate cells
+using PlutoUI
+```
+
+```julia
+using MarkdownLiteral: @mdx
+```
+
+```julia
+# ❌ WRONG — syntax error
+using PlutoUI, MarkdownLiteral: @mdx
+```
+
 ### Checklist
 
 After finishing the notebook content, run through these steps:
@@ -704,9 +742,11 @@ After finishing the notebook content, run through these steps:
 2. Add `TableOfContents()` right after the title
 3. Move results/summary cells near the top, below the TOC
 4. Move boilerplate (imports, helpers, constants) to the bottom
-5. Fold all markdown cells, plot cells, TOC, and boilerplate
-6. Ensure each section has a markdown header
-7. `save_notebook` to persist the final layout
+5. Move any `Pkg` cells to the very end
+6. Fold all markdown cells, plot cells, TOC, and boilerplate
+7. Ensure each section has a markdown header
+8. **Run `list_cells` and check for errors** — verify no cells are in an errored state. If something crashed, fix it before saving. A beautified notebook that doesn't run is worse than an ugly one that does.
+9. `save_notebook` to persist the final layout
 
 ---
 

--- a/src/__tests__/plutoManager.test.ts
+++ b/src/__tests__/plutoManager.test.ts
@@ -1,8 +1,27 @@
 import { PlutoManager, PlutoManagerLogger } from "../plutoManager.js";
+import type { IPlutoServerManager, IFileReader } from "../plutoManagerTypes.js";
 import { spawn, ChildProcess, execSync } from "child_process";
-import { writeFile, unlink, mkdir } from "fs/promises";
+import { writeFile, unlink, mkdir, readFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
+
+/** Stub server manager for tests that connect to an already-running Pluto */
+function createStubServerManager(port: number): IPlutoServerManager {
+  return {
+    start: async () => {},
+    stop: async () => {},
+    isRunning: () => false,
+    waitForReady: async () => {},
+    onStop: () => {},
+    onPortChanged: () => {},
+    getActualPort: () => port,
+    getServerUrl: () => `http://localhost:${port}`,
+  };
+}
+
+const nodeFileReader: IFileReader = {
+  readFile: (path: string) => readFile(path, "utf-8"),
+};
 
 describe("PlutoManager Integration Tests", () => {
   let plutoProcess: ChildProcess | null = null;
@@ -157,7 +176,13 @@ x = 42
 
     // Create PlutoManager instance
     console.log("[TEST] Creating PlutoManager instance...");
-    manager = new PlutoManager(TEST_PORT, mockLogger, SERVER_URL);
+    manager = new PlutoManager(
+      TEST_PORT,
+      mockLogger,
+      createStubServerManager(TEST_PORT),
+      nodeFileReader,
+      SERVER_URL
+    );
     console.log("[TEST] PlutoManager setup complete!");
   }, 150000);
 
@@ -387,7 +412,12 @@ x = 42
         showInfoMessage: async () => undefined,
         showErrorMessage: async () => undefined,
       };
-      const testManager = new PlutoManager(TEST_PORT, logger);
+      const testManager = new PlutoManager(
+        TEST_PORT,
+        logger,
+        createStubServerManager(TEST_PORT),
+        nodeFileReader
+      );
       expect(testManager.getServerUrl()).toBe(SERVER_URL);
     });
 
@@ -398,7 +428,13 @@ x = 42
         showErrorMessage: async () => undefined,
       };
       const customUrl = "http://custom-server:5678";
-      const testManager = new PlutoManager(TEST_PORT, logger, customUrl);
+      const testManager = new PlutoManager(
+        TEST_PORT,
+        logger,
+        createStubServerManager(TEST_PORT),
+        nodeFileReader,
+        customUrl
+      );
       expect(testManager.getServerUrl()).toBe(customUrl);
     });
   });

--- a/src/cli/call.ts
+++ b/src/cli/call.ts
@@ -1,0 +1,222 @@
+/**
+ * MCP tool caller — connects to a running MCP server via SSE,
+ * sends JSON-RPC requests, and prints responses.
+ * Uses raw fetch + SSE parsing to avoid eventsource polyfill issues in CJS bundles.
+ */
+
+interface JsonRpcResponse {
+  jsonrpc: string;
+  id: number;
+  result?: {
+    tools?: Array<{
+      name: string;
+      description?: string;
+      inputSchema?: { properties?: Record<string, unknown> };
+    }>;
+    content?: Array<{ type: string; text?: string }>;
+    isError?: boolean;
+  };
+  error?: { code: number; message: string };
+}
+
+async function mcpRequest(
+  port: number,
+  method: string,
+  params: Record<string, unknown> = {}
+): Promise<JsonRpcResponse["result"]> {
+  const sseUrl = `http://localhost:${port}/mcp`;
+
+  // 1. Open SSE connection to get session endpoint
+  const sseResponse = await fetch(sseUrl, {
+    headers: { Accept: "text/event-stream" },
+  });
+
+  if (!sseResponse.ok || !sseResponse.body) {
+    throw new Error(
+      `Failed to connect to MCP server at ${sseUrl} (${sseResponse.status})`
+    );
+  }
+
+  const reader = sseResponse.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let sessionUrl: string | undefined;
+
+  // Read until we get the endpoint event
+  while (!sessionUrl) {
+    const { done, value } = await reader.read();
+    if (done) throw new Error("SSE stream ended before receiving endpoint");
+    buffer += decoder.decode(value, { stream: true });
+
+    const lines = buffer.split("\n");
+    for (let i = 0; i < lines.length - 1; i++) {
+      const line = lines[i];
+      if (line.startsWith("data: ") && !sessionUrl) {
+        sessionUrl = line.slice(6).trim();
+      }
+    }
+    buffer = lines[lines.length - 1];
+  }
+
+  const messagesUrl = `http://localhost:${port}${sessionUrl}`;
+  const requestId = 1;
+
+  // 2. First send initialize
+  await fetch(messagesUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 0,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "plutojl-mcp-cli", version: "0.1.0" },
+      },
+    }),
+  });
+
+  // Read and discard the initialize response
+  let initDone = false;
+  while (!initDone) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    if (buffer.includes('"initialize"') || buffer.includes('"id":0')) {
+      initDone = true;
+    }
+  }
+
+  // Send initialized notification
+  await fetch(messagesUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    }),
+  });
+
+  // 3. Send the actual request
+  await fetch(messagesUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: requestId,
+      method,
+      params,
+    }),
+  });
+
+  // 4. Read SSE events until we get our response
+  buffer = "";
+  const timeout = setTimeout(() => {
+    reader.cancel().catch(() => {});
+  }, 30000);
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      // Parse SSE events from buffer
+      const parts = buffer.split("\n\n");
+      buffer = parts.pop() ?? "";
+
+      for (const part of parts) {
+        let eventData = "";
+        for (const line of part.split("\n")) {
+          if (line.startsWith("data: ")) {
+            eventData += line.slice(6);
+          }
+        }
+        if (eventData) {
+          try {
+            const parsed = JSON.parse(eventData) as JsonRpcResponse;
+            if (parsed.id === requestId) {
+              if (parsed.error) {
+                throw new Error(
+                  `MCP error ${parsed.error.code}: ${parsed.error.message}`
+                );
+              }
+              return parsed.result;
+            }
+          } catch (e) {
+            if (e instanceof SyntaxError) continue; // not JSON, skip
+            throw e;
+          }
+        }
+      }
+    }
+  } finally {
+    clearTimeout(timeout);
+    reader.cancel().catch(() => {});
+  }
+
+  throw new Error("No response received from MCP server");
+}
+
+export async function listTools(port: number): Promise<void> {
+  const result = await mcpRequest(port, "tools/list");
+  const tools = result?.tools ?? [];
+
+  if (tools.length === 0) {
+    console.log("No tools available.");
+    return;
+  }
+
+  const maxLen = Math.max(...tools.map((t) => t.name.length));
+
+  for (const tool of tools) {
+    const params = tool.inputSchema?.properties
+      ? Object.keys(tool.inputSchema.properties)
+      : [];
+    const paramStr = params.length > 0 ? `  (${params.join(", ")})` : "";
+    console.log(
+      `  ${tool.name.padEnd(maxLen)}  ${tool.description ?? ""}${paramStr}`
+    );
+  }
+}
+
+export async function callTool(
+  port: number,
+  toolName: string,
+  argsJson: string,
+  raw: boolean
+): Promise<void> {
+  let args: Record<string, unknown>;
+  try {
+    args = JSON.parse(argsJson) as Record<string, unknown>;
+  } catch {
+    console.error(`Invalid JSON arguments: ${argsJson}`);
+    process.exit(1);
+  }
+
+  const result = await mcpRequest(port, "tools/call", {
+    name: toolName,
+    arguments: args,
+  });
+
+  if (raw) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  const content = result?.content as
+    | Array<{ type: string; text?: string }>
+    | undefined;
+  if (content) {
+    for (const item of content) {
+      if (item.type === "text" && item.text) {
+        console.log(item.text);
+      }
+    }
+  }
+
+  if (result?.isError) {
+    process.exit(1);
+  }
+}

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -15,6 +15,11 @@ export interface InstallArgs {
   force: boolean;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const pkg = require("../../packages/advanced-pluto-mcp/package.json");
+
+export const VERSION: string = pkg.version;
+
 export const DEFAULTS = {
   mcpPort: 3100,
   plutoPort: 1234,

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,0 +1,21 @@
+export interface CliConfig {
+  mcpPort: number;
+  plutoPort: number;
+  plutoUrl: string | undefined;
+  juliaVersion: string;
+  workDir: string;
+}
+
+export interface InstallArgs {
+  target: "claude-code" | "copilot" | "all";
+  mcpPort: number;
+  global: boolean;
+  dryRun: boolean;
+  force: boolean;
+}
+
+export const DEFAULTS = {
+  mcpPort: 3100,
+  plutoPort: 1234,
+  juliaVersion: "1.11.7",
+} as const;

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -4,6 +4,7 @@ export interface CliConfig {
   plutoUrl: string | undefined;
   juliaVersion: string;
   workDir: string;
+  noPluto: boolean;
 }
 
 export interface InstallArgs {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,26 @@
+import { parseArgs } from "./parseArgs.ts";
+import { resolveRunConfig, resolveInstallArgs } from "./resolveConfig.ts";
+import { run } from "./run.ts";
+import { installMcpConfig } from "./install.ts";
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  switch (args.command) {
+    case "run": {
+      const config = resolveRunConfig(args);
+      await run(config);
+      break;
+    }
+    case "install": {
+      const installArgs = resolveInstallArgs(args);
+      await installMcpConfig(installArgs);
+      break;
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,7 +28,7 @@ async function main() {
     }
     case "call": {
       if (!args.toolName) {
-        console.error("Usage: npx @plutojl/mcp call <tool_name> [json_args]");
+        console.error("Usage: npx @plutojl/cli call <tool_name> [json_args]");
         process.exit(1);
       }
       await preflight(mcpPort);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,9 +2,12 @@ import { parseArgs } from "./parseArgs.ts";
 import { resolveRunConfig, resolveInstallArgs } from "./resolveConfig.ts";
 import { run } from "./run.ts";
 import { installMcpConfig } from "./install.ts";
+import { callTool, listTools } from "./call.ts";
+import { DEFAULTS } from "./config.ts";
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
+  const mcpPort = args.mcpPort ?? DEFAULTS.mcpPort;
 
   switch (args.command) {
     case "run": {
@@ -15,6 +18,23 @@ async function main() {
     case "install": {
       const installArgs = resolveInstallArgs(args);
       await installMcpConfig(installArgs);
+      break;
+    }
+    case "tools": {
+      await listTools(mcpPort);
+      break;
+    }
+    case "call": {
+      if (!args.toolName) {
+        console.error("Usage: npx @plutojl/mcp call <tool_name> [json_args]");
+        process.exit(1);
+      }
+      await callTool(
+        mcpPort,
+        args.toolName,
+        args.toolArgs ?? "{}",
+        args.raw ?? false
+      );
       break;
     }
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@ import { resolveRunConfig, resolveInstallArgs } from "./resolveConfig.ts";
 import { run } from "./run.ts";
 import { installMcpConfig } from "./install.ts";
 import { callTool, listTools } from "./call.ts";
+import { preflight } from "./preflight.ts";
 import { DEFAULTS } from "./config.ts";
 
 async function main() {
@@ -21,6 +22,7 @@ async function main() {
       break;
     }
     case "tools": {
+      await preflight(mcpPort);
       await listTools(mcpPort);
       break;
     }
@@ -29,6 +31,7 @@ async function main() {
         console.error("Usage: npx @plutojl/mcp call <tool_name> [json_args]");
         process.exit(1);
       }
+      await preflight(mcpPort);
       await callTool(
         mcpPort,
         args.toolName,

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -94,7 +94,7 @@ function installCopilot(
 }
 
 export async function installMcpConfig(args: InstallArgs): Promise<void> {
-  console.log("advanced-pluto-mcp — Installing MCP configuration\n");
+  console.log("@plutojl/mcp — Installing MCP configuration\n");
 
   const targets =
     args.target === "all" ? ["claude-code", "copilot"] : [args.target];
@@ -110,6 +110,6 @@ export async function installMcpConfig(args: InstallArgs): Promise<void> {
   }
 
   if (!args.dryRun) {
-    console.log("Done! Start the MCP server with: npx advanced-pluto-mcp run");
+    console.log("Done! Start the MCP server with: npx @plutojl/mcp run");
   }
 }

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -94,7 +94,7 @@ function installCopilot(
 }
 
 export async function installMcpConfig(args: InstallArgs): Promise<void> {
-  console.log("@plutojl/mcp — Installing MCP configuration\n");
+  console.log("@plutojl/cli — Installing MCP configuration\n");
 
   const targets =
     args.target === "all" ? ["claude-code", "copilot"] : [args.target];
@@ -110,6 +110,6 @@ export async function installMcpConfig(args: InstallArgs): Promise<void> {
   }
 
   if (!args.dryRun) {
-    console.log("Done! Start the MCP server with: npx @plutojl/mcp run");
+    console.log("Done! Start the MCP server with: npx @plutojl/cli run");
   }
 }

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,0 +1,115 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import type { InstallArgs } from "./config.ts";
+
+interface JsonObject {
+  [key: string]: unknown;
+}
+
+function readJsonFile(filePath: string): JsonObject {
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    return JSON.parse(raw) as JsonObject;
+  } catch {
+    return {};
+  }
+}
+
+function writeJsonFile(
+  filePath: string,
+  data: JsonObject,
+  dryRun: boolean
+): void {
+  const content = JSON.stringify(data, null, 2) + "\n";
+  if (dryRun) {
+    console.log(`[dry-run] Would write to ${filePath}:`);
+    console.log(content);
+    return;
+  }
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(filePath, content, "utf-8");
+  console.log(`  Written: ${filePath}`);
+}
+
+function installClaudeCode(
+  mcpPort: number,
+  global: boolean,
+  dryRun: boolean,
+  force: boolean
+): void {
+  // Claude Code reads MCP configs from:
+  //   Project-level: .mcp.json at project root
+  //   Global: ~/.claude.json (user-level)
+  const filePath = global
+    ? path.join(os.homedir(), ".claude.json")
+    : path.join(process.cwd(), ".mcp.json");
+
+  const existing = readJsonFile(filePath);
+  const mcpServers = (existing.mcpServers ?? {}) as JsonObject;
+
+  if (mcpServers["pluto-notebook"] && !force && !dryRun) {
+    console.log(
+      `  Skipping ${filePath} — pluto-notebook already configured (use --force to overwrite)`
+    );
+    return;
+  }
+
+  mcpServers["pluto-notebook"] = {
+    type: "http",
+    url: `http://localhost:${mcpPort}/mcp`,
+  };
+
+  existing.mcpServers = mcpServers;
+  writeJsonFile(filePath, existing, dryRun);
+}
+
+function installCopilot(
+  mcpPort: number,
+  dryRun: boolean,
+  force: boolean
+): void {
+  const filePath = path.join(process.cwd(), "mcp.json");
+  const existing = readJsonFile(filePath);
+  const servers = (existing.servers ?? {}) as JsonObject;
+
+  if (servers["pluto-notebook"] && !force && !dryRun) {
+    console.log(
+      `  Skipping ${filePath} — pluto-notebook already configured (use --force to overwrite)`
+    );
+    return;
+  }
+
+  servers["pluto-notebook"] = {
+    url: `http://localhost:${mcpPort}/mcp`,
+    type: "http",
+  };
+
+  existing.servers = servers;
+  if (!existing.inputs) {
+    existing.inputs = [];
+  }
+  writeJsonFile(filePath, existing, dryRun);
+}
+
+export async function installMcpConfig(args: InstallArgs): Promise<void> {
+  console.log("advanced-pluto-mcp — Installing MCP configuration\n");
+
+  const targets =
+    args.target === "all" ? ["claude-code", "copilot"] : [args.target];
+
+  for (const target of targets) {
+    console.log(`Target: ${target}`);
+    if (target === "claude-code") {
+      installClaudeCode(args.mcpPort, args.global, args.dryRun, args.force);
+    } else if (target === "copilot") {
+      installCopilot(args.mcpPort, args.dryRun, args.force);
+    }
+    console.log();
+  }
+
+  if (!args.dryRun) {
+    console.log("Done! Start the MCP server with: npx advanced-pluto-mcp run");
+  }
+}

--- a/src/cli/logger.ts
+++ b/src/cli/logger.ts
@@ -1,0 +1,16 @@
+import type { PlutoManagerLogger } from "../plutoManager.ts";
+
+export const consoleLogger: PlutoManagerLogger = {
+  showWarningMessage: async (msg: string) => {
+    console.warn(`[warn] ${msg}`);
+    return undefined;
+  },
+  showInfoMessage: async (msg: string) => {
+    console.log(`[info] ${msg}`);
+    return undefined;
+  },
+  showErrorMessage: async (msg: string) => {
+    console.error(`[error] ${msg}`);
+    return undefined;
+  },
+};

--- a/src/cli/nodeFileReader.ts
+++ b/src/cli/nodeFileReader.ts
@@ -1,0 +1,8 @@
+import { readFile } from "fs/promises";
+import type { IFileReader } from "../plutoManagerTypes.ts";
+
+export class NodeFileReader implements IFileReader {
+  async readFile(path: string): Promise<string> {
+    return await readFile(path, "utf-8");
+  }
+}

--- a/src/cli/nodeServerManager.ts
+++ b/src/cli/nodeServerManager.ts
@@ -1,0 +1,301 @@
+import { spawn, spawnSync, type ChildProcess } from "child_process";
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs";
+import type { IPlutoServerManager } from "../plutoManagerTypes.ts";
+import { isPortAvailable, findAvailablePort } from "../portUtils.ts";
+import { getExecutableName, isWindows } from "../platformUtils.ts";
+
+export class NodeServerManager implements IPlutoServerManager {
+  private juliaProcess?: ChildProcess;
+  private actualPort: number;
+  private starting = false;
+  private onStopCallback?: () => void;
+  private onPortChangedCallback?: (port: number) => void;
+
+  constructor(
+    private readonly port: number,
+    private readonly juliaVersion: string,
+    private readonly workDir: string
+  ) {
+    this.actualPort = port;
+  }
+
+  isRunning(): boolean {
+    return !!this.juliaProcess || this.starting;
+  }
+
+  onStop(callback: () => void): void {
+    this.onStopCallback = callback;
+  }
+
+  onPortChanged(callback: (port: number) => void): void {
+    this.onPortChangedCallback = callback;
+  }
+
+  getActualPort(): number {
+    return this.actualPort;
+  }
+
+  getServerUrl(): string {
+    return `http://localhost:${this.actualPort}`;
+  }
+
+  async waitForReady(): Promise<void> {
+    // start() already polls — nothing extra needed
+  }
+
+  async start(): Promise<void> {
+    if (this.juliaProcess || this.starting) {
+      throw new Error("Pluto server is already running");
+    }
+    this.starting = true;
+
+    try {
+      // 1. Check port availability
+      const portAvailable = await isPortAvailable(this.port);
+      if (!portAvailable) {
+        console.log(
+          `[pluto] Port ${this.port} is in use, finding alternative...`
+        );
+        this.actualPort = await findAvailablePort(this.port);
+        console.log(`[pluto] Using port ${this.actualPort}`);
+        if (this.actualPort !== this.port && this.onPortChangedCallback) {
+          this.onPortChangedCallback(this.actualPort);
+        }
+      } else {
+        this.actualPort = this.port;
+      }
+
+      // 2. Check Julia is available
+      const juliaCmd = getExecutableName("julia");
+      const juliaCheck = spawnSync(juliaCmd, ["--version"], {
+        stdio: "pipe",
+        timeout: 10000,
+      });
+      if (juliaCheck.error) {
+        console.error(
+          "Error: Julia not found. Please install Julia from https://julialang.org/downloads/"
+        );
+        console.error(
+          "  or install juliaup from https://github.com/JuliaLang/juliaup#installation"
+        );
+        process.exit(1);
+      }
+
+      // 3. Try juliaup to ensure the requested version is available
+      let useJuliaupPrefix = true;
+      const juliaupCmd = getExecutableName("juliaup");
+      const juliaupResult = spawnSync(juliaupCmd, ["add", this.juliaVersion], {
+        stdio: "pipe",
+        timeout: 60000,
+      });
+      if (juliaupResult.error) {
+        console.log(
+          "[pluto] juliaup not found — using system julia (ignoring --julia-version)"
+        );
+        useJuliaupPrefix = false;
+      } else if (juliaupResult.status !== 0) {
+        console.warn(
+          `[pluto] juliaup add ${this.juliaVersion} failed (exit ${juliaupResult.status}), continuing with system julia`
+        );
+        useJuliaupPrefix = false;
+      }
+
+      // 4. Build Julia arguments
+      const juliaArgs = useJuliaupPrefix ? [`+${this.juliaVersion}`] : [];
+
+      // 5. Environment variables
+      const env: Record<string, string> = {
+        ...(process.env as Record<string, string>),
+        JULIA_DEPOT_PATH: path.join(os.homedir(), ".julia"),
+        JULIA_LOAD_PATH: isWindows() ? ";" : ":",
+      };
+      if (this.workDir) {
+        env.JULIA_PLUTO_VSCODE_WORKSPACE = this.workDir;
+      }
+
+      // 6. Optional JuliaHub auth
+      this.tryJuliaHubAuth(env, juliaCmd, juliaArgs);
+
+      // 7. Setup task — install Pluto if needed
+      console.log(
+        "[pluto] Setting up Julia environment (first run may take a few minutes)..."
+      );
+      const setupCode = [
+        "import Pkg",
+        "s = string",
+        `Pkg.activate(mkpath(joinpath(Pkg.depots1(), s(:environments), s(:vscode_pluto_notebook), string(VERSION))))`,
+        "Pkg.Registry.add()",
+        "Pkg.add(s(:Pluto))",
+        "Pkg.add(s(:Pkg))",
+        "Pkg.instantiate()",
+        "Pkg.precompile()",
+      ].join(";");
+
+      const setupResult = spawnSync(juliaCmd, [...juliaArgs, "-e", setupCode], {
+        stdio: "inherit",
+        env,
+        timeout: 600000,
+      });
+      if (setupResult.status !== 0) {
+        throw new Error(
+          `Julia setup failed with exit code ${setupResult.status}`
+        );
+      }
+
+      // 8. Start Pluto server
+      const runCode = `import Pkg;s = string;Pkg.activate(mkpath(joinpath(Pkg.depots1(), s(:environments), s(:vscode_pluto_notebook), string(VERSION))));using Pluto; Pluto.run(port=${this.actualPort}; require_secret_for_open_links=false, require_secret_for_access=false, launch_browser=false)`;
+
+      console.log(
+        `[pluto] Starting Pluto server on port ${this.actualPort}...`
+      );
+      this.juliaProcess = spawn(juliaCmd, [...juliaArgs, "-e", runCode], {
+        stdio: ["ignore", "pipe", "pipe"],
+        env,
+      });
+
+      this.juliaProcess.stdout?.on("data", (data: Buffer) => {
+        process.stderr.write(`[julia] ${data}`);
+      });
+      this.juliaProcess.stderr?.on("data", (data: Buffer) => {
+        process.stderr.write(`[julia] ${data}`);
+      });
+
+      this.juliaProcess.on("exit", (code) => {
+        console.log(`[pluto] Julia process exited with code ${code}`);
+        this.juliaProcess = undefined;
+        this.starting = false;
+        this.actualPort = this.port;
+        this.onStopCallback?.();
+      });
+
+      this.juliaProcess.on("error", (err) => {
+        console.error(`[pluto] Julia process error: ${err.message}`);
+        this.juliaProcess = undefined;
+        this.starting = false;
+      });
+
+      // 9. Poll until server is ready
+      await this.pollServerReady();
+      this.starting = false;
+      console.log(`[pluto] Pluto server is ready at ${this.getServerUrl()}`);
+    } catch (err) {
+      this.starting = false;
+      // Kill process if it was started
+      if (this.juliaProcess) {
+        this.juliaProcess.kill();
+        this.juliaProcess = undefined;
+      }
+      throw err;
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (!this.juliaProcess) return;
+    this.juliaProcess.kill();
+    // Wait briefly for process to exit
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => {
+        // Force kill if still alive
+        if (this.juliaProcess) {
+          this.juliaProcess.kill("SIGKILL");
+        }
+        resolve();
+      }, 5000);
+
+      if (this.juliaProcess) {
+        this.juliaProcess.on("exit", () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+      } else {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+    this.juliaProcess = undefined;
+    this.actualPort = this.port;
+  }
+
+  private tryJuliaHubAuth(
+    env: Record<string, string>,
+    juliaCmd: string,
+    juliaArgs: string[]
+  ): void {
+    try {
+      const jhCmd = getExecutableName("jh");
+      const tmpFile = path.join(
+        os.tmpdir(),
+        `.pluto-mcp-auth-${process.pid}.txt`
+      );
+
+      const script = [
+        `s = string`,
+        `auth_path = "${tmpFile.replace(/\\/g, "/")}"`,
+        `try output = read(\`${jhCmd} auth env\`, String)`,
+        `    open(io -> write(io, output), auth_path, s(:w))`,
+        `catch e`,
+        `    open(io -> write(io, s()), auth_path, s(:w))`,
+        `end`,
+        `try read(\`${jhCmd} auth refresh\`, String)`,
+        `catch e;`,
+        `end`,
+      ].join(";");
+
+      const result = spawnSync(juliaCmd, [...juliaArgs, "-e", script], {
+        env: { ...env, VSCODE_PLUTO_AUTH_FILE: tmpFile },
+        stdio: "pipe",
+        timeout: 15000,
+      });
+
+      if (result.status === 0 && fs.existsSync(tmpFile)) {
+        const content = fs.readFileSync(tmpFile, "utf-8");
+        fs.unlinkSync(tmpFile);
+
+        for (const line of content.split("\n")) {
+          const trimmed = line.trim();
+          if (trimmed && trimmed.includes("=")) {
+            const [key, ...valueParts] = trimmed.split("=");
+            const value = valueParts.join("=");
+            if (key.trim() === "JULIAHUB_HOST" && value.trim()) {
+              env.JULIA_PKG_SERVER = value.trim();
+              console.log(`[pluto] Using JULIAHUB_HOST: ${value.trim()}`);
+            }
+          }
+        }
+      }
+    } catch {
+      // jh not available — skip silently
+    }
+  }
+
+  private async pollServerReady(): Promise<void> {
+    // Initial wait for Julia to start up
+    await new Promise((r) => setTimeout(r, 5000));
+
+    const maxAttempts = 120;
+    const pollInterval = 1000;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      // Check if process died
+      if (!this.juliaProcess) {
+        throw new Error("Julia process exited before server became ready");
+      }
+
+      try {
+        const response = await fetch(this.getServerUrl(), {
+          method: "GET",
+          signal: AbortSignal.timeout(2000),
+        });
+        if (response) return;
+      } catch {
+        // Not ready yet
+      }
+
+      await new Promise((r) => setTimeout(r, pollInterval));
+    }
+
+    throw new Error(`Pluto server did not start within ${maxAttempts} seconds`);
+  }
+}

--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -15,10 +15,10 @@ export interface RawArgs {
 
 function printHelp(): void {
   console.log(`
-advanced-pluto-mcp — Standalone MCP server for Pluto.jl notebooks
+@plutojl/mcp — Standalone MCP server for Pluto.jl notebooks
 
 Usage:
-  advanced-pluto-mcp <command> [options]
+  npx @plutojl/mcp <command> [options]
 
 Commands:
   run       Start the MCP server (and Pluto server if needed)
@@ -38,10 +38,10 @@ Install options:
   --force                  Overwrite existing config without prompting
 
 Examples:
-  npx advanced-pluto-mcp run
-  npx advanced-pluto-mcp run --pluto-url http://localhost:1234
-  npx advanced-pluto-mcp install
-  npx advanced-pluto-mcp install --target all --global
+  npx @plutojl/mcp run
+  npx @plutojl/mcp run --pluto-url http://localhost:1234
+  npx @plutojl/mcp install
+  npx @plutojl/mcp install --target all --global
 `);
 }
 

--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -11,6 +11,8 @@ export interface RawArgs {
   global?: boolean;
   dryRun?: boolean;
   force?: boolean;
+  // run-specific
+  noPluto?: boolean;
   // call-specific
   toolName?: string;
   toolArgs?: string;
@@ -35,6 +37,7 @@ Run options:
   --pluto-port <port>      Pluto server port (default: ${DEFAULTS.plutoPort})
   --pluto-url <url>        Connect to existing Pluto server (skip starting one)
   --julia-version <ver>    Julia version via juliaup (default: ${DEFAULTS.juliaVersion})
+  --no-pluto               Start MCP server only, without starting Pluto
 
 Install options:
   --target <target>        Config target: claude-code, copilot, all (default: claude-code)
@@ -143,6 +146,8 @@ export function parseArgs(argv: string[]): RawArgs {
       args.force = true;
     } else if (flag === "--raw") {
       args.raw = true;
+    } else if (flag === "--no-pluto") {
+      args.noPluto = true;
     } else {
       console.warn(`Unknown flag: ${flag}`);
     }

--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -1,7 +1,7 @@
 import { DEFAULTS } from "./config.ts";
 
 export interface RawArgs {
-  command: "run" | "install" | "help";
+  command: "run" | "install" | "call" | "tools" | "help";
   mcpPort?: number;
   plutoPort?: number;
   plutoUrl?: string;
@@ -11,6 +11,10 @@ export interface RawArgs {
   global?: boolean;
   dryRun?: boolean;
   force?: boolean;
+  // call-specific
+  toolName?: string;
+  toolArgs?: string;
+  raw?: boolean;
 }
 
 function printHelp(): void {
@@ -22,7 +26,9 @@ Usage:
 
 Commands:
   run       Start the MCP server (and Pluto server if needed)
-  install   Add MCP config to .claude/ or .vscode/ directory
+  install   Add MCP config to .mcp.json or mcp.json
+  tools     List available MCP tools on a running server
+  call      Call an MCP tool on a running server
 
 Run options:
   --mcp-port <port>        MCP server port (default: ${DEFAULTS.mcpPort})
@@ -37,13 +43,27 @@ Install options:
   --dry-run                Print config without writing
   --force                  Overwrite existing config without prompting
 
+Call options:
+  npx @plutojl/mcp call <tool_name> [json_args]
+  --mcp-port <port>        MCP server port (default: ${DEFAULTS.mcpPort})
+  --raw                    Output raw JSON response
+
+Tools options:
+  --mcp-port <port>        MCP server port (default: ${DEFAULTS.mcpPort})
+
 Examples:
   npx @plutojl/mcp run
   npx @plutojl/mcp run --pluto-url http://localhost:1234
   npx @plutojl/mcp install
   npx @plutojl/mcp install --target all --global
+  npx @plutojl/mcp tools
+  npx @plutojl/mcp call get_notebook_status
+  npx @plutojl/mcp call start_pluto_server '{"port": 1234}'
+  npx @plutojl/mcp call open_notebook '{"path": "/tmp/nb.pluto.jl"}'
 `);
 }
+
+const COMMANDS = new Set(["run", "install", "call", "tools", "help"]);
 
 export function parseArgs(argv: string[]): RawArgs {
   const args: RawArgs = { command: "help" };
@@ -61,14 +81,27 @@ export function parseArgs(argv: string[]): RawArgs {
 
   if (i < argv.length) {
     const cmd = argv[i];
-    if (cmd === "run" || cmd === "install" || cmd === "help") {
-      args.command = cmd;
+    if (COMMANDS.has(cmd)) {
+      args.command = cmd as RawArgs["command"];
     } else {
       console.error(`Unknown command: ${cmd}`);
       printHelp();
       process.exit(1);
     }
     i++;
+  }
+
+  // For `call`, grab positional args: tool_name and optional json_args
+  if (args.command === "call") {
+    // Collect positional args (non-flag tokens) before any flags
+    while (i < argv.length && !argv[i].startsWith("-")) {
+      if (!args.toolName) {
+        args.toolName = argv[i];
+      } else if (!args.toolArgs) {
+        args.toolArgs = argv[i];
+      }
+      i++;
+    }
   }
 
   // Parse flags
@@ -108,6 +141,8 @@ export function parseArgs(argv: string[]): RawArgs {
       args.dryRun = true;
     } else if (flag === "--force") {
       args.force = true;
+    } else if (flag === "--raw") {
+      args.raw = true;
     } else {
       console.warn(`Unknown flag: ${flag}`);
     }

--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -21,10 +21,10 @@ export interface RawArgs {
 
 function printHelp(): void {
   console.log(`
-@plutojl/mcp v${VERSION} — Standalone MCP server for Pluto.jl notebooks
+@plutojl/cli v${VERSION} — Standalone MCP server for Pluto.jl notebooks
 
 Usage:
-  npx @plutojl/mcp <command> [options]
+  npx @plutojl/cli <command> [options]
 
 Commands:
   run       Start the MCP server (and Pluto server if needed)
@@ -47,7 +47,7 @@ Install options:
   --force                  Overwrite existing config without prompting
 
 Call options:
-  npx @plutojl/mcp call <tool_name> [json_args]
+  npx @plutojl/cli call <tool_name> [json_args]
   --mcp-port <port>        MCP server port (default: ${DEFAULTS.mcpPort})
   --raw                    Output raw JSON response
 
@@ -55,14 +55,14 @@ Tools options:
   --mcp-port <port>        MCP server port (default: ${DEFAULTS.mcpPort})
 
 Examples:
-  npx @plutojl/mcp run
-  npx @plutojl/mcp run --pluto-url http://localhost:1234
-  npx @plutojl/mcp install
-  npx @plutojl/mcp install --target all --global
-  npx @plutojl/mcp tools
-  npx @plutojl/mcp call get_notebook_status
-  npx @plutojl/mcp call start_pluto_server '{"port": 1234}'
-  npx @plutojl/mcp call open_notebook '{"path": "/tmp/nb.pluto.jl"}'
+  npx @plutojl/cli run
+  npx @plutojl/cli run --pluto-url http://localhost:1234
+  npx @plutojl/cli install
+  npx @plutojl/cli install --target all --global
+  npx @plutojl/cli tools
+  npx @plutojl/cli call get_notebook_status
+  npx @plutojl/cli call start_pluto_server '{"port": 1234}'
+  npx @plutojl/cli call open_notebook '{"path": "/tmp/nb.pluto.jl"}'
 `);
 }
 

--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -1,0 +1,124 @@
+import { DEFAULTS } from "./config.ts";
+
+export interface RawArgs {
+  command: "run" | "install" | "help";
+  mcpPort?: number;
+  plutoPort?: number;
+  plutoUrl?: string;
+  juliaVersion?: string;
+  // install-specific
+  target?: "claude-code" | "copilot" | "all";
+  global?: boolean;
+  dryRun?: boolean;
+  force?: boolean;
+}
+
+function printHelp(): void {
+  console.log(`
+advanced-pluto-mcp — Standalone MCP server for Pluto.jl notebooks
+
+Usage:
+  advanced-pluto-mcp <command> [options]
+
+Commands:
+  run       Start the MCP server (and Pluto server if needed)
+  install   Add MCP config to .claude/ or .vscode/ directory
+
+Run options:
+  --mcp-port <port>        MCP server port (default: ${DEFAULTS.mcpPort})
+  --pluto-port <port>      Pluto server port (default: ${DEFAULTS.plutoPort})
+  --pluto-url <url>        Connect to existing Pluto server (skip starting one)
+  --julia-version <ver>    Julia version via juliaup (default: ${DEFAULTS.juliaVersion})
+
+Install options:
+  --target <target>        Config target: claude-code, copilot, all (default: claude-code)
+  --mcp-port <port>        MCP server port to configure (default: ${DEFAULTS.mcpPort})
+  --global                 Write to ~/.claude.json instead of ./.mcp.json
+  --dry-run                Print config without writing
+  --force                  Overwrite existing config without prompting
+
+Examples:
+  npx advanced-pluto-mcp run
+  npx advanced-pluto-mcp run --pluto-url http://localhost:1234
+  npx advanced-pluto-mcp install
+  npx advanced-pluto-mcp install --target all --global
+`);
+}
+
+export function parseArgs(argv: string[]): RawArgs {
+  const args: RawArgs = { command: "help" };
+
+  let i = 0;
+
+  // First non-flag token is the command
+  while (i < argv.length && argv[i].startsWith("-")) {
+    if (argv[i] === "--help" || argv[i] === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+    i++;
+  }
+
+  if (i < argv.length) {
+    const cmd = argv[i];
+    if (cmd === "run" || cmd === "install" || cmd === "help") {
+      args.command = cmd;
+    } else {
+      console.error(`Unknown command: ${cmd}`);
+      printHelp();
+      process.exit(1);
+    }
+    i++;
+  }
+
+  // Parse flags
+  while (i < argv.length) {
+    const flag = argv[i];
+
+    if (flag === "--help" || flag === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+
+    if (flag === "--mcp-port" && i + 1 < argv.length) {
+      args.mcpPort = parseInt(argv[++i], 10);
+    } else if (flag === "--pluto-port" && i + 1 < argv.length) {
+      args.plutoPort = parseInt(argv[++i], 10);
+    } else if (flag === "--pluto-url" && i + 1 < argv.length) {
+      args.plutoUrl = argv[++i];
+    } else if (flag === "--julia-version" && i + 1 < argv.length) {
+      args.juliaVersion = argv[++i];
+    } else if (flag === "--target" && i + 1 < argv.length) {
+      const target = argv[++i];
+      if (
+        target === "claude-code" ||
+        target === "copilot" ||
+        target === "all"
+      ) {
+        args.target = target;
+      } else {
+        console.error(
+          `Unknown target: ${target} (use claude-code, copilot, or all)`
+        );
+        process.exit(1);
+      }
+    } else if (flag === "--global") {
+      args.global = true;
+    } else if (flag === "--dry-run") {
+      args.dryRun = true;
+    } else if (flag === "--force") {
+      args.force = true;
+    } else {
+      console.warn(`Unknown flag: ${flag}`);
+    }
+
+    i++;
+  }
+
+  if (args.command === "help") {
+    printHelp();
+    process.exit(0);
+  }
+
+  return args;
+}

--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -1,4 +1,4 @@
-import { DEFAULTS } from "./config.ts";
+import { DEFAULTS, VERSION } from "./config.ts";
 
 export interface RawArgs {
   command: "run" | "install" | "call" | "tools" | "help";
@@ -21,7 +21,7 @@ export interface RawArgs {
 
 function printHelp(): void {
   console.log(`
-@plutojl/mcp — Standalone MCP server for Pluto.jl notebooks
+@plutojl/mcp v${VERSION} — Standalone MCP server for Pluto.jl notebooks
 
 Usage:
   npx @plutojl/mcp <command> [options]

--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -21,16 +21,16 @@ export interface RawArgs {
 
 function printHelp(): void {
   console.log(`
-@plutojl/cli v${VERSION} — Standalone MCP server for Pluto.jl notebooks
+@plutojl/cli v${VERSION} — command-line tool for Pluto.jl notebooks
 
 Usage:
   npx @plutojl/cli <command> [options]
 
 Commands:
-  run       Start the MCP server (and Pluto server if needed)
-  install   Add MCP config to .mcp.json or mcp.json
-  tools     List available MCP tools on a running server
-  call      Call an MCP tool on a running server
+  run       Start Pluto and the tool server
+  tools     List available notebook tools
+  call      Call a notebook tool (open, edit, execute cells, ...)
+  install   Add MCP config for AI assistants (.mcp.json or mcp.json)
 
 Run options:
   --mcp-port <port>        MCP server port (default: ${DEFAULTS.mcpPort})

--- a/src/cli/preflight.ts
+++ b/src/cli/preflight.ts
@@ -1,0 +1,60 @@
+/**
+ * Preflight checks for CLI commands that need a running MCP (and optionally Pluto) server.
+ * Prints clear diagnostics and exits if something is missing.
+ */
+
+interface HealthResponse {
+  status: string;
+  plutoServerRunning: boolean;
+  activeSessions: number;
+}
+
+interface PreflightResult {
+  mcpRunning: true;
+  plutoRunning: boolean;
+}
+
+export async function preflight(
+  port: number,
+  opts: { requirePluto?: boolean } = {}
+): Promise<PreflightResult> {
+  const mcpUrl = `http://localhost:${port}`;
+
+  // 1. Check MCP server
+  let health: HealthResponse;
+  try {
+    const res = await fetch(`${mcpUrl}/health`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    health = (await res.json()) as HealthResponse;
+  } catch {
+    console.error(`Error: Cannot reach MCP server at ${mcpUrl}`);
+    console.error(``);
+    console.error(`The MCP server is not running. Start it first:`);
+    console.error(``);
+    console.error(`  npx @plutojl/mcp run`);
+    console.error(``);
+    console.error(
+      `Or, if you are using a different port, pass --mcp-port <port>.`
+    );
+    process.exit(1);
+  }
+
+  // 2. Check Pluto server (if required)
+  if (opts.requirePluto && !health.plutoServerRunning) {
+    console.error(`Error: MCP server is running but Pluto is not connected.`);
+    console.error(``);
+    console.error(`Start Pluto via the MCP server:`);
+    console.error(``);
+    console.error(`  npx @plutojl/mcp call start_pluto_server`);
+    console.error(``);
+    console.error(`Or connect to an existing Pluto server:`);
+    console.error(``);
+    console.error(
+      `  npx @plutojl/mcp call connect_to_pluto_server '{"port": 1234}'`
+    );
+    process.exit(1);
+  }
+
+  return { mcpRunning: true, plutoRunning: health.plutoServerRunning };
+}

--- a/src/cli/preflight.ts
+++ b/src/cli/preflight.ts
@@ -32,7 +32,7 @@ export async function preflight(
     console.error(``);
     console.error(`The MCP server is not running. Start it first:`);
     console.error(``);
-    console.error(`  npx @plutojl/mcp run`);
+    console.error(`  npx @plutojl/cli run`);
     console.error(``);
     console.error(
       `Or, if you are using a different port, pass --mcp-port <port>.`
@@ -46,12 +46,12 @@ export async function preflight(
     console.error(``);
     console.error(`Start Pluto via the MCP server:`);
     console.error(``);
-    console.error(`  npx @plutojl/mcp call start_pluto_server`);
+    console.error(`  npx @plutojl/cli call start_pluto_server`);
     console.error(``);
     console.error(`Or connect to an existing Pluto server:`);
     console.error(``);
     console.error(
-      `  npx @plutojl/mcp call connect_to_pluto_server '{"port": 1234}'`
+      `  npx @plutojl/cli call connect_to_pluto_server '{"port": 1234}'`
     );
     process.exit(1);
   }

--- a/src/cli/resolveConfig.ts
+++ b/src/cli/resolveConfig.ts
@@ -54,6 +54,7 @@ export function resolveRunConfig(args: RawArgs): CliConfig {
       file.juliaVersion ??
       DEFAULTS.juliaVersion,
     workDir,
+    noPluto: args.noPluto ?? false,
   };
 }
 

--- a/src/cli/resolveConfig.ts
+++ b/src/cli/resolveConfig.ts
@@ -1,0 +1,68 @@
+import * as fs from "fs";
+import * as path from "path";
+import type { CliConfig, InstallArgs } from "./config.ts";
+import { DEFAULTS } from "./config.ts";
+import type { RawArgs } from "./parseArgs.ts";
+
+interface ConfigFile {
+  plutoPort?: number;
+  mcpPort?: number;
+  juliaVersion?: string;
+  serverUrl?: string;
+}
+
+function loadConfigFile(dir: string): ConfigFile {
+  const filePath = path.join(dir, ".plutomcp.json");
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    return JSON.parse(raw) as ConfigFile;
+  } catch {
+    return {};
+  }
+}
+
+function envInt(name: string): number | undefined {
+  const val = process.env[name];
+  if (val === undefined) return undefined;
+  const n = parseInt(val, 10);
+  return isNaN(n) ? undefined : n;
+}
+
+export function resolveRunConfig(args: RawArgs): CliConfig {
+  const workDir = process.cwd();
+  const file = loadConfigFile(workDir);
+
+  return {
+    mcpPort:
+      args.mcpPort ??
+      envInt("PLUTO_MCP_PORT") ??
+      file.mcpPort ??
+      DEFAULTS.mcpPort,
+    plutoPort:
+      args.plutoPort ??
+      envInt("PLUTO_PORT") ??
+      file.plutoPort ??
+      DEFAULTS.plutoPort,
+    plutoUrl:
+      args.plutoUrl ??
+      process.env.PLUTO_SERVER_URL ??
+      file.serverUrl ??
+      undefined,
+    juliaVersion:
+      args.juliaVersion ??
+      process.env.JULIA_VERSION ??
+      file.juliaVersion ??
+      DEFAULTS.juliaVersion,
+    workDir,
+  };
+}
+
+export function resolveInstallArgs(args: RawArgs): InstallArgs {
+  return {
+    target: args.target ?? "claude-code",
+    mcpPort: args.mcpPort ?? envInt("PLUTO_MCP_PORT") ?? DEFAULTS.mcpPort,
+    global: args.global ?? false,
+    dryRun: args.dryRun ?? false,
+    force: args.force ?? false,
+  };
+}

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -7,7 +7,7 @@ import { consoleLogger } from "./logger.ts";
 import type { CliConfig } from "./config.ts";
 
 export async function run(config: CliConfig): Promise<void> {
-  console.log("advanced-pluto-mcp — Standalone MCP server for Pluto.jl\n");
+  console.log("@plutojl/mcp — Standalone MCP server for Pluto.jl\n");
 
   let serverManager: NodeServerManager | undefined;
   let plutoManager: PlutoManager;
@@ -54,9 +54,7 @@ export async function run(config: CliConfig): Promise<void> {
   );
   console.log(`[cli] Health check: http://localhost:${config.mcpPort}/health`);
   console.log(`[cli] Press Ctrl+C to stop\n`);
-  console.log(
-    `Tip: Run 'npx advanced-pluto-mcp install' to configure Claude Code\n`
-  );
+  console.log(`Tip: Run 'npx @plutojl/mcp install' to configure Claude Code\n`);
 
   // Graceful shutdown
   const shutdown = async () => {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -9,51 +9,58 @@ import type { CliConfig } from "./config.ts";
 export async function run(config: CliConfig): Promise<void> {
   console.log("@plutojl/mcp — Standalone MCP server for Pluto.jl\n");
 
-  let serverManager: NodeServerManager | undefined;
-  let plutoManager: PlutoManager;
+  const serverManager = new NodeServerManager(
+    config.plutoPort,
+    config.juliaVersion,
+    config.workDir
+  );
 
-  if (config.plutoUrl) {
-    // Connect to existing Pluto server
-    console.log(
-      `[cli] Connecting to existing Pluto server at ${config.plutoUrl}`
-    );
-    // Create a dummy server manager that does nothing (Pluto is externally managed)
-    serverManager = new NodeServerManager(
-      config.plutoPort,
-      config.juliaVersion,
-      config.workDir
-    );
-    plutoManager = new PlutoManager(
-      config.plutoPort,
-      consoleLogger,
-      serverManager,
-      new NodeFileReader(),
-      config.plutoUrl
-    );
-  } else {
-    // Start our own Pluto server
-    serverManager = new NodeServerManager(
-      config.plutoPort,
-      config.juliaVersion,
-      config.workDir
-    );
-    plutoManager = new PlutoManager(
-      config.plutoPort,
-      consoleLogger,
-      serverManager,
-      new NodeFileReader()
-    );
-  }
+  const plutoManager = new PlutoManager(
+    config.plutoPort,
+    consoleLogger,
+    serverManager,
+    new NodeFileReader(),
+    config.plutoUrl
+  );
 
-  // Start the MCP HTTP server (handleSignals = true for CLI)
+  // Start the MCP HTTP server first (so health endpoint is available during Pluto startup)
   const mcpServer = new PlutoMCPHttpServer(plutoManager, config.mcpPort, true);
   await mcpServer.start();
 
   console.log(
-    `\n[cli] MCP server listening at http://localhost:${config.mcpPort}/mcp`
+    `[cli] MCP server listening at http://localhost:${config.mcpPort}/mcp`
   );
   console.log(`[cli] Health check: http://localhost:${config.mcpPort}/health`);
-  console.log(`[cli] Press Ctrl+C to stop\n`);
+
+  // Auto-start Pluto unless --no-pluto was passed
+  if (!config.noPluto) {
+    if (config.plutoUrl) {
+      console.log(
+        `[cli] Connecting to existing Pluto server at ${config.plutoUrl}...`
+      );
+    } else {
+      console.log(`[cli] Starting Pluto server on port ${config.plutoPort}...`);
+    }
+    try {
+      await plutoManager.start();
+      console.log(`[cli] Pluto server is ready.`);
+    } catch (err) {
+      console.error(
+        `[cli] Failed to start Pluto: ${err instanceof Error ? err.message : String(err)}`
+      );
+      console.error(
+        `[cli] MCP server is still running — you can start Pluto later via:`
+      );
+      console.error(`[cli]   npx @plutojl/mcp call start_pluto_server`);
+    }
+  } else {
+    console.log(`[cli] Pluto auto-start skipped (--no-pluto).`);
+    console.log(
+      `[cli] Start it later: npx @plutojl/mcp call start_pluto_server`
+    );
+  }
+
+  console.log(`\n[cli] Press Ctrl+C to stop\n`);
   console.log(`Tip: Run 'npx @plutojl/mcp install' to configure Claude Code\n`);
 
   // Graceful shutdown

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,0 +1,78 @@
+import "@plutojl/rainbow/node-polyfill";
+import { PlutoManager } from "../plutoManager.ts";
+import { PlutoMCPHttpServer } from "../mcp-server-http.ts";
+import { NodeServerManager } from "./nodeServerManager.ts";
+import { NodeFileReader } from "./nodeFileReader.ts";
+import { consoleLogger } from "./logger.ts";
+import type { CliConfig } from "./config.ts";
+
+export async function run(config: CliConfig): Promise<void> {
+  console.log("advanced-pluto-mcp — Standalone MCP server for Pluto.jl\n");
+
+  let serverManager: NodeServerManager | undefined;
+  let plutoManager: PlutoManager;
+
+  if (config.plutoUrl) {
+    // Connect to existing Pluto server
+    console.log(
+      `[cli] Connecting to existing Pluto server at ${config.plutoUrl}`
+    );
+    // Create a dummy server manager that does nothing (Pluto is externally managed)
+    serverManager = new NodeServerManager(
+      config.plutoPort,
+      config.juliaVersion,
+      config.workDir
+    );
+    plutoManager = new PlutoManager(
+      config.plutoPort,
+      consoleLogger,
+      serverManager,
+      new NodeFileReader(),
+      config.plutoUrl
+    );
+  } else {
+    // Start our own Pluto server
+    serverManager = new NodeServerManager(
+      config.plutoPort,
+      config.juliaVersion,
+      config.workDir
+    );
+    plutoManager = new PlutoManager(
+      config.plutoPort,
+      consoleLogger,
+      serverManager,
+      new NodeFileReader()
+    );
+  }
+
+  // Start the MCP HTTP server (handleSignals = true for CLI)
+  const mcpServer = new PlutoMCPHttpServer(plutoManager, config.mcpPort, true);
+  await mcpServer.start();
+
+  console.log(
+    `\n[cli] MCP server listening at http://localhost:${config.mcpPort}/mcp`
+  );
+  console.log(`[cli] Health check: http://localhost:${config.mcpPort}/health`);
+  console.log(`[cli] Press Ctrl+C to stop\n`);
+  console.log(
+    `Tip: Run 'npx advanced-pluto-mcp install' to configure Claude Code\n`
+  );
+
+  // Graceful shutdown
+  const shutdown = async () => {
+    console.log("\n[cli] Shutting down...");
+    try {
+      await mcpServer.stop();
+    } catch {
+      // ignore
+    }
+    try {
+      await plutoManager.stop();
+    } catch {
+      // ignore
+    }
+    process.exit(0);
+  };
+
+  process.on("SIGTERM", () => void shutdown());
+}

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -4,10 +4,12 @@ import { PlutoMCPHttpServer } from "../mcp-server-http.ts";
 import { NodeServerManager } from "./nodeServerManager.ts";
 import { NodeFileReader } from "./nodeFileReader.ts";
 import { consoleLogger } from "./logger.ts";
-import type { CliConfig } from "./config.ts";
+import { type CliConfig, VERSION } from "./config.ts";
 
 export async function run(config: CliConfig): Promise<void> {
-  console.log("@plutojl/mcp — Standalone MCP server for Pluto.jl\n");
+  console.log(
+    `@plutojl/mcp v${VERSION} — Standalone MCP server for Pluto.jl\n`
+  );
 
   const serverManager = new NodeServerManager(
     config.plutoPort,

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -8,7 +8,7 @@ import { type CliConfig, VERSION } from "./config.ts";
 
 export async function run(config: CliConfig): Promise<void> {
   console.log(
-    `@plutojl/mcp v${VERSION} — Standalone MCP server for Pluto.jl\n`
+    `@plutojl/cli v${VERSION} — Standalone MCP server for Pluto.jl\n`
   );
 
   const serverManager = new NodeServerManager(
@@ -53,17 +53,17 @@ export async function run(config: CliConfig): Promise<void> {
       console.error(
         `[cli] MCP server is still running — you can start Pluto later via:`
       );
-      console.error(`[cli]   npx @plutojl/mcp call start_pluto_server`);
+      console.error(`[cli]   npx @plutojl/cli call start_pluto_server`);
     }
   } else {
     console.log(`[cli] Pluto auto-start skipped (--no-pluto).`);
     console.log(
-      `[cli] Start it later: npx @plutojl/mcp call start_pluto_server`
+      `[cli] Start it later: npx @plutojl/cli call start_pluto_server`
     );
   }
 
   console.log(`\n[cli] Press Ctrl+C to stop\n`);
-  console.log(`Tip: Run 'npx @plutojl/mcp install' to configure Claude Code\n`);
+  console.log(`Tip: Run 'npx @plutojl/cli install' to configure Claude Code\n`);
 
   // Graceful shutdown
   const shutdown = async () => {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -7,9 +7,7 @@ import { consoleLogger } from "./logger.ts";
 import { type CliConfig, VERSION } from "./config.ts";
 
 export async function run(config: CliConfig): Promise<void> {
-  console.log(
-    `@plutojl/cli v${VERSION} — Standalone MCP server for Pluto.jl\n`
-  );
+  console.log(`@plutojl/cli v${VERSION} — command-line tool for Pluto.jl\n`);
 
   const serverManager = new NodeServerManager(
     config.plutoPort,

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -790,10 +790,47 @@ export class PlutoMCPHttpServer {
       }
     );
 
+    // Fold/Unfold Cell
+    server.tool(
+      "fold_cell",
+      "Show or hide a cell's code in the Pluto notebook. Folded cells hide their source code but still show output. Use list_cells to find cell IDs.",
+      {
+        path: z.string().describe("Path to the notebook"),
+        cell_id: z.string().describe("UUID of the cell to fold/unfold"),
+        folded: z
+          .boolean()
+          .describe(
+            "true to hide (fold) the cell code, false to show (unfold) it"
+          ),
+      },
+      async ({ path, cell_id, folded }) => {
+        if (!this.plutoManager.isConnected()) {
+          throw new Error("Pluto server is not running");
+        }
+
+        const worker = await this.plutoManager.getWorker(path);
+
+        if (!worker) {
+          throw new Error(`Notebook ${path} is not open`);
+        }
+
+        await this.plutoManager.foldCell(worker, cell_id, folded);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Cell ${cell_id} ${folded ? "folded (code hidden)" : "unfolded (code visible)"}`,
+            },
+          ],
+        };
+      }
+    );
+
     // List Cells
     server.tool(
       "list_cells",
-      "List all cells in a notebook with their IDs, code preview, and execution status. Use this to find cell IDs for read_cell, edit_cell, execute_cell, delete_cell, or move_cells.",
+      "List all cells in a notebook with their IDs, code preview, and execution status. Use this to find cell IDs for read_cell, edit_cell, execute_cell, delete_cell, move_cells, or fold_cell.",
       {
         path: z.string().describe("Path to the notebook"),
       },
@@ -814,6 +851,7 @@ export class PlutoMCPHttpServer {
           cell_id: snippet.cell_id,
           index,
           code_preview: snippet.input.code.split("\n")[0].slice(0, 80),
+          code_folded: snippet.input.code_folded,
           errored: snippet.result.errored,
           running: snippet.result.running,
           queued: snippet.result.queued,

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -165,11 +165,15 @@ export class PlutoMCPHttpServer {
         }
 
         await this.plutoManager.stop();
+
+        const stillRunning = this.plutoManager.isRunning();
         return {
           content: [
             {
               type: "text",
-              text: "Pluto server stopped",
+              text: stillRunning
+                ? "Warning: stop() returned but the server process may still be running. It should be force-killed shortly."
+                : "Pluto server stopped",
             },
           ],
         };

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -200,11 +200,56 @@ export class PlutoMCPHttpServer {
           throw new Error("Failed to create worker for notebook");
         }
 
+        const isLocal = this.plutoManager.isLocalServer();
+        const syncNote = isLocal
+          ? "Pluto is tracking this file path and will save changes to it."
+          : "Warning: Pluto server is remote — the file on disk is NOT synced with the server. Use save_notebook to write changes back to the local file.";
+
         return {
           content: [
             {
               type: "text",
-              text: `Notebook opened: ${path}\nNotebook ID: ${worker.notebook_id}`,
+              text: `Notebook opened: ${path}\nNotebook ID: ${worker.notebook_id}\n${syncNote}`,
+            },
+          ],
+        };
+      }
+    );
+
+    // Move Notebook
+    server.tool(
+      "move_notebook",
+      "Move a notebook to a new file path. Pluto will save to the new path, delete the old file, and move any associated .assets directory. Only works when the server is on localhost.",
+      {
+        path: z.string().describe("Current path of the open notebook"),
+        new_path: z
+          .string()
+          .describe("Absolute path for the new notebook location"),
+      },
+      async ({ path, new_path }) => {
+        if (!this.plutoManager.isConnected()) {
+          throw new Error("Pluto server is not running");
+        }
+
+        if (!this.plutoManager.isLocalServer()) {
+          throw new Error(
+            "move_notebook only works when the Pluto server is on localhost (shared filesystem). Use save_notebook to write a copy instead."
+          );
+        }
+
+        const worker = await this.plutoManager.getWorker(path);
+
+        if (!worker) {
+          throw new Error(`Notebook ${path} is not open`);
+        }
+
+        await this.plutoManager.moveNotebook(worker, new_path);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Notebook moved from ${path} to ${new_path}. Pluto is now tracking the new path.`,
             },
           ],
         };

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -751,10 +751,49 @@ export class PlutoMCPHttpServer {
       }
     );
 
+    // Move Cells
+    server.tool(
+      "move_cells",
+      "Move one or more cells to a new position in the notebook. The order of cell_ids is preserved in the result. Use list_cells to find cell IDs and their current positions.",
+      {
+        path: z.string().describe("Path to the notebook"),
+        cell_ids: z
+          .array(z.string())
+          .describe("Cell UUIDs to move, in desired order"),
+        index: z
+          .number()
+          .describe(
+            "Target position in the current cell order (before removing the moved cells). E.g. 0 = beginning, 1 = after first cell."
+          ),
+      },
+      async ({ path, cell_ids, index }) => {
+        if (!this.plutoManager.isConnected()) {
+          throw new Error("Pluto server is not running");
+        }
+
+        const worker = await this.plutoManager.getWorker(path);
+
+        if (!worker) {
+          throw new Error(`Notebook ${path} is not open`);
+        }
+
+        await this.plutoManager.moveCells(worker, cell_ids, index);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Moved ${cell_ids.length} cell(s) to position ${index}`,
+            },
+          ],
+        };
+      }
+    );
+
     // List Cells
     server.tool(
       "list_cells",
-      "List all cells in a notebook with their IDs, code preview, and execution status. Use this to find cell IDs for read_cell, edit_cell, execute_cell, or delete_cell.",
+      "List all cells in a notebook with their IDs, code preview, and execution status. Use this to find cell IDs for read_cell, edit_cell, execute_cell, delete_cell, or move_cells.",
       {
         path: z.string().describe("Path to the notebook"),
       },

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import type { Express, Request, Response } from "express";
 import type { Server as HttpServer } from "http";
+import { writeFile } from "fs/promises";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import type { PlutoManager } from "./plutoManager.ts";
@@ -178,7 +179,7 @@ export class PlutoMCPHttpServer {
     // Open Notebook
     server.tool(
       "open_notebook",
-      "Open a Pluto notebook file and create a worker session",
+      "Open a Pluto notebook file and create a worker session. The .jl file must already exist on disk — Pluto will not create a new file from a nonexistent path. Create the file first if needed.",
       {
         path: z.string().describe("Path to the .jl notebook file"),
       },
@@ -260,7 +261,7 @@ export class PlutoMCPHttpServer {
     // Create Cell
     server.tool(
       "create_cell",
-      "Create and execute a new cell in a notebook",
+      "Create and execute a new cell in a notebook. WARNING: This always executes the code. If the code is slow (e.g. package installs), the call may time out but the cell IS still created in Pluto. Use list_cells to check before retrying. For slow operations, prefer edit_cell with run=false then execute_cell separately.",
       {
         path: z.string().describe("Path to the notebook"),
         code: z.string().describe("Julia code for the new cell"),
@@ -303,7 +304,7 @@ export class PlutoMCPHttpServer {
     // Edit Cell
     server.tool(
       "edit_cell",
-      "Update the code of an existing cell",
+      "Update the code of an existing cell. Note: editing the .pluto.jl file on disk has NO effect on the running notebook — all mutations must go through the MCP API. Use save_notebook to persist changes to disk.",
       {
         path: z.string().describe("Path to the notebook"),
         cell_id: z.string().describe("UUID of the cell to edit"),
@@ -676,6 +677,148 @@ export class PlutoMCPHttpServer {
             ],
           };
         }
+      }
+    );
+
+    // Save Notebook
+    server.tool(
+      "save_notebook",
+      "Save the running notebook to disk as a .pluto.jl file. Notebooks are NOT auto-saved — you must call this explicitly to persist changes made via create_cell, edit_cell, or delete_cell.",
+      {
+        path: z.string().describe("Path of the open notebook"),
+        output_path: z
+          .string()
+          .describe(
+            "Optional alternative file path to save to (defaults to the notebook's original path)"
+          )
+          .optional(),
+      },
+      async ({ path, output_path }) => {
+        if (!this.plutoManager.isConnected()) {
+          throw new Error("Pluto server is not running");
+        }
+
+        const worker = await this.plutoManager.getWorker(path);
+
+        if (!worker) {
+          throw new Error(`Notebook ${path} is not open`);
+        }
+
+        const content = this.plutoManager.getNotebookContent(worker);
+        const savePath = output_path ?? path;
+        await writeFile(savePath, content, "utf-8");
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Notebook saved to ${savePath} (${content.length} bytes)`,
+            },
+          ],
+        };
+      }
+    );
+
+    // Delete Cell
+    server.tool(
+      "delete_cell",
+      "Permanently remove a cell from the notebook by its ID. Use list_cells to find cell IDs.",
+      {
+        path: z.string().describe("Path to the notebook"),
+        cell_id: z.string().describe("UUID of the cell to delete"),
+      },
+      async ({ path, cell_id }) => {
+        if (!this.plutoManager.isConnected()) {
+          throw new Error("Pluto server is not running");
+        }
+
+        const worker = await this.plutoManager.getWorker(path);
+
+        if (!worker) {
+          throw new Error(`Notebook ${path} is not open`);
+        }
+
+        await this.plutoManager.deleteCell(worker, cell_id);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Cell ${cell_id} deleted`,
+            },
+          ],
+        };
+      }
+    );
+
+    // List Cells
+    server.tool(
+      "list_cells",
+      "List all cells in a notebook with their IDs, code preview, and execution status. Use this to find cell IDs for read_cell, edit_cell, execute_cell, or delete_cell.",
+      {
+        path: z.string().describe("Path to the notebook"),
+      },
+      async ({ path }) => {
+        if (!this.plutoManager.isConnected()) {
+          throw new Error("Pluto server is not running");
+        }
+
+        const worker = await this.plutoManager.getWorker(path);
+
+        if (!worker) {
+          throw new Error(`Notebook ${path} is not open`);
+        }
+
+        const snippets = worker.getSnippets();
+
+        const cells = snippets.map((snippet, index) => ({
+          cell_id: snippet.cell_id,
+          index,
+          code_preview: snippet.input.code.split("\n")[0].slice(0, 80),
+          errored: snippet.result.errored,
+          running: snippet.result.running,
+          queued: snippet.result.queued,
+        }));
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ count: cells.length, cells }, null, 2),
+            },
+          ],
+        };
+      }
+    );
+
+    // Get Notebook URL
+    server.tool(
+      "get_notebook_url",
+      "Get the browser URL to open the notebook in Pluto's web interface",
+      {
+        path: z.string().describe("Path to the notebook"),
+      },
+      async ({ path }) => {
+        if (!this.plutoManager.isConnected()) {
+          throw new Error("Pluto server is not running");
+        }
+
+        const worker = await this.plutoManager.getWorker(path);
+
+        if (!worker) {
+          throw new Error(`Notebook ${path} is not open`);
+        }
+
+        const url = `${this.plutoManager.getServerUrl()}/edit?id=${worker.notebook_id}`;
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: url,
+            },
+          ],
+        };
       }
     );
   }

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -21,10 +21,12 @@ export class PlutoMCPHttpServer {
   private readonly transports: Map<string, SSEServerTransport> = new Map();
   private readonly plutoManager: PlutoManager;
   private readonly port: number;
+  private readonly handleSignals: boolean;
 
-  constructor(plutoManager: PlutoManager, port = 3100) {
+  constructor(plutoManager: PlutoManager, port = 3100, handleSignals = false) {
     this.plutoManager = plutoManager;
     this.port = port;
+    this.handleSignals = handleSignals;
     this.app = express();
     this.app.use(express.json());
     this.setupRoutes();
@@ -144,7 +146,13 @@ export class PlutoMCPHttpServer {
       "Stop the running Pluto server",
       {},
       async () => {
-        if (!this.plutoManager.isRunning()) {
+        // Use isConnected() instead of isRunning() — we may be connected
+        // to an externally-managed server (no owned process), and stop
+        // should still disconnect and clean up.
+        if (
+          !this.plutoManager.isConnected() &&
+          !this.plutoManager.isRunning()
+        ) {
           return {
             content: [
               {
@@ -747,6 +755,9 @@ export class PlutoMCPHttpServer {
   }
 
   private setupErrorHandling(): void {
+    if (!this.handleSignals) {
+      return;
+    }
     process.on("SIGINT", async () => {
       console.log("[MCP HTTP] Shutting down server...");
       await this.stop();

--- a/src/plutoManager.ts
+++ b/src/plutoManager.ts
@@ -219,20 +219,26 @@ export class PlutoManager {
   }
 
   /**
-   * Stop Pluto server
+   * Stop Pluto server. Times out worker shutdown after 10s to avoid hanging.
    */
   public async stop(): Promise<void> {
-    // Close all workers — tolerate failures (worker may already be dead)
-    for (const worker of this.workers.values()) {
-      try {
-        await worker.shutdown();
-      } catch {
-        // Worker shutdown can fail if server is already gone — ignore
-      }
-    }
+    // Close all workers with a timeout — don't let a hung worker block shutdown
+    const workerShutdown = Promise.allSettled(
+      [...this.workers.values()].map((worker) =>
+        worker.shutdown().catch(() => {
+          // Worker shutdown can fail if server is already gone — ignore
+        })
+      )
+    );
+
+    const timeoutMs = 10_000;
+    await Promise.race([
+      workerShutdown,
+      new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+    ]);
     this.workers.clear();
 
-    // Stop server process
+    // Stop server process (NodeServerManager already has its own 5s SIGKILL fallback)
     if (this.serverManager.isRunning()) {
       await this.serverManager.stop();
     }

--- a/src/plutoManager.ts
+++ b/src/plutoManager.ts
@@ -285,6 +285,14 @@ export class PlutoManager {
         }
 
         worker = await this.host.createWorker(notebookContent.trim());
+        await worker.connect();
+
+        // Tell Pluto which file this notebook lives at so it can track saves.
+        // Only works when the server shares the same filesystem (localhost).
+        if (this.isLocalServer()) {
+          await worker.moveTo(notebookPath);
+        }
+
         this.workers.set(notebookPath, worker);
 
         // Emit notebook opened event
@@ -395,6 +403,32 @@ export class PlutoManager {
       { notebook_id: worker.notebook_id },
       false
     );
+  }
+
+  /**
+   * Move a notebook to a new file path via Pluto (updates Pluto's tracked path,
+   * moves the file and .assets directory on the server side).
+   */
+  public async moveNotebook(worker: Worker, newPath: string): Promise<void> {
+    await worker.moveTo(newPath);
+  }
+
+  /**
+   * Whether the Pluto server is running on localhost (file paths are shared).
+   */
+  public isLocalServer(): boolean {
+    try {
+      const url = new URL(this.serverUrl);
+      const host = url.hostname;
+      return (
+        host === "localhost" ||
+        host === "127.0.0.1" ||
+        host === "::1" ||
+        host === "0.0.0.0"
+      );
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/src/plutoManager.ts
+++ b/src/plutoManager.ts
@@ -344,6 +344,17 @@ export class PlutoManager {
   }
 
   /**
+   * Move cells to a new position in the notebook
+   */
+  public async moveCells(
+    worker: Worker,
+    cellIds: string[],
+    index: number
+  ): Promise<void> {
+    await worker.moveSnippets(cellIds, index);
+  }
+
+  /**
    * Get the server URL
    */
   public getServerUrl(): string {

--- a/src/plutoManager.ts
+++ b/src/plutoManager.ts
@@ -2,6 +2,7 @@ import type { CellResultData, Worker } from "@plutojl/rainbow";
 import { Host, serialize } from "@plutojl/rainbow";
 import type { IPlutoServerManager, IFileReader } from "./plutoManagerTypes.ts";
 import { EventEmitter } from "events";
+import { unlink } from "fs/promises";
 
 /**
  * Events emitted by PlutoManager
@@ -289,7 +290,9 @@ export class PlutoManager {
 
         // Tell Pluto which file this notebook lives at so it can track saves.
         // Only works when the server shares the same filesystem (localhost).
+        // We must delete the file first — moveTo throws if the path already exists.
         if (this.isLocalServer()) {
+          await unlink(notebookPath);
           await worker.moveTo(notebookPath);
         }
 

--- a/src/plutoManager.ts
+++ b/src/plutoManager.ts
@@ -1,7 +1,6 @@
 import type { CellResultData, Worker } from "@plutojl/rainbow";
 import { Host } from "@plutojl/rainbow";
-import * as vscode from "vscode";
-import { PlutoServerTaskManager } from "./plutoServerTask.js";
+import type { IPlutoServerManager, IFileReader } from "./plutoManagerTypes.ts";
 import { EventEmitter } from "events";
 
 /**
@@ -36,7 +35,6 @@ export class PlutoManager {
   private host?: Host; // Host from @plutojl/rainbow
   private readonly workers: Map<string, Worker> = new Map(); // notebook_id -> Worker
   private serverUrl: string;
-  private readonly taskManager: PlutoServerTaskManager;
   private usingCustomServerUrl = false;
   private readonly notebooksToRecreate: Set<string> = new Set(); // Paths of notebooks to recreate after reconnect
   private readonly eventEmitter: EventEmitter = new EventEmitter();
@@ -44,6 +42,8 @@ export class PlutoManager {
   constructor(
     private readonly port = 1234,
     private readonly logger: PlutoManagerLogger,
+    private readonly serverManager: IPlutoServerManager,
+    private readonly fileReader: IFileReader,
     serverUrl?: string
   ) {
     if (serverUrl) {
@@ -53,15 +53,13 @@ export class PlutoManager {
       this.serverUrl = `http://localhost:${this.port}`;
     }
 
-    this.taskManager = new PlutoServerTaskManager(this.port);
-
     // Register callback to reset state when server task stops
-    this.taskManager.onStop(() => {
+    this.serverManager.onStop(() => {
       this.onServerStopped();
     });
 
     // Register callback to update server URL when port changes
-    this.taskManager.onPortChanged((newPort: number) => {
+    this.serverManager.onPortChanged((newPort: number) => {
       this.serverUrl = `http://localhost:${newPort}`;
       // Update host with new URL
       if (this.host) {
@@ -123,7 +121,7 @@ export class PlutoManager {
     this.emit("serverStateChanged");
 
     // Show warning to user if server stopped unexpectedly
-    if (!this.taskManager.isRunning()) {
+    if (!this.serverManager.isRunning()) {
       this.logger
         .showErrorMessage(
           "Pluto server stopped unexpectedly. Click 'Restart' to start it again.",
@@ -145,7 +143,7 @@ export class PlutoManager {
    * Check if Pluto server is running
    */
   public isRunning(): boolean {
-    return this.taskManager.isRunning() && this.isConnected();
+    return this.serverManager.isRunning() && this.isConnected();
   }
 
   /**
@@ -178,12 +176,12 @@ export class PlutoManager {
     }
 
     // Check if already running
-    if (this.taskManager.isRunning()) {
+    if (this.serverManager.isRunning()) {
       return;
     }
 
-    await this.taskManager.start();
-    await this.taskManager.waitForReady();
+    await this.serverManager.start();
+    await this.serverManager.waitForReady();
     await this.connect();
 
     // Emit server state changed event
@@ -224,15 +222,19 @@ export class PlutoManager {
    * Stop Pluto server
    */
   public async stop(): Promise<void> {
-    // Close all workers
+    // Close all workers — tolerate failures (worker may already be dead)
     for (const worker of this.workers.values()) {
-      await worker.shutdown();
+      try {
+        await worker.shutdown();
+      } catch {
+        // Worker shutdown can fail if server is already gone — ignore
+      }
     }
     this.workers.clear();
 
-    // Stop task
-    if (this.taskManager.isRunning()) {
-      await this.taskManager.stop();
+    // Stop server process
+    if (this.serverManager.isRunning()) {
+      await this.serverManager.stop();
     }
 
     this.host = undefined;
@@ -271,13 +273,9 @@ export class PlutoManager {
       let notebookContent: string;
       try {
         if (documentContent) {
-          // Use provided VSCode document content
           notebookContent = documentContent;
         } else {
-          // Read from file system using VSCode API
-          const fileUri = vscode.Uri.file(notebookPath);
-          const fileContent = await vscode.workspace.fs.readFile(fileUri);
-          notebookContent = new TextDecoder().decode(fileContent);
+          notebookContent = await this.fileReader.readFile(notebookPath);
         }
 
         worker = await this.host.createWorker(notebookContent.trim());
@@ -357,7 +355,7 @@ export class PlutoManager {
    * This may differ from the configured port if the configured port was unavailable
    */
   public getActualPort(): number {
-    return this.taskManager.getActualPort();
+    return this.serverManager.getActualPort();
   }
 
   /**
@@ -417,8 +415,8 @@ export class PlutoManager {
     this.workers.clear();
 
     // Stop task (fire and forget - dispose is not async)
-    if (this.taskManager.isRunning()) {
-      await this.taskManager.stop().catch(() => {
+    if (this.serverManager.isRunning()) {
+      await this.serverManager.stop().catch(() => {
         // Ignore errors during dispose
       });
     }

--- a/src/plutoManager.ts
+++ b/src/plutoManager.ts
@@ -355,6 +355,43 @@ export class PlutoManager {
   }
 
   /**
+   * Set the code_folded state of a cell (show/hide code in Pluto UI)
+   */
+  public async foldCell(
+    worker: Worker,
+    cellId: string,
+    folded: boolean
+  ): Promise<void> {
+    if (!worker.client || !worker.notebook_state) {
+      throw new Error("Not connected to notebook");
+    }
+
+    const cellInput = worker.notebook_state.cell_inputs[cellId];
+    if (!cellInput) {
+      throw new Error(`Cell ${cellId} not found`);
+    }
+
+    if (cellInput.code_folded === folded) {
+      return; // Already in desired state
+    }
+
+    const updates = [
+      {
+        op: "replace" as const,
+        path: ["cell_inputs", cellId, "code_folded"],
+        value: folded,
+      },
+    ];
+
+    await worker.client.send(
+      "update_notebook",
+      { updates },
+      { notebook_id: worker.notebook_id },
+      false
+    );
+  }
+
+  /**
    * Get the server URL
    */
   public getServerUrl(): string {

--- a/src/plutoManager.ts
+++ b/src/plutoManager.ts
@@ -1,5 +1,5 @@
 import type { CellResultData, Worker } from "@plutojl/rainbow";
-import { Host } from "@plutojl/rainbow";
+import { Host, serialize } from "@plutojl/rainbow";
 import type { IPlutoServerManager, IFileReader } from "./plutoManagerTypes.ts";
 import { EventEmitter } from "events";
 
@@ -403,6 +403,17 @@ export class PlutoManager {
     await worker.deleteSnippets([result.cell_id]);
 
     return result;
+  }
+
+  /**
+   * Get the serialized notebook content (.jl format) for saving to disk
+   */
+  public getNotebookContent(worker: Worker): string {
+    const state = worker.getState();
+    if (!state) {
+      throw new Error("Notebook state not available");
+    }
+    return serialize(state);
   }
 
   /**

--- a/src/plutoManagerInstance.ts
+++ b/src/plutoManagerInstance.ts
@@ -1,5 +1,7 @@
 import type { PlutoManagerLogger } from "./plutoManager.ts";
 import { PlutoManager } from "./plutoManager.ts";
+import { PlutoServerTaskManager } from "./plutoServerTask.ts";
+import { VscodeFileReader } from "./vscodeFileReader.ts";
 
 /**
  * Shared PlutoManager instance that can be used by both the extension and MCP server
@@ -12,7 +14,13 @@ export function getSharedPlutoManager(
   logger: PlutoManagerLogger,
   serverUrl?: string
 ): PlutoManager {
-  sharedPlutoManager ??= new PlutoManager(port, logger, serverUrl);
+  sharedPlutoManager ??= new PlutoManager(
+    port,
+    logger,
+    new PlutoServerTaskManager(port),
+    new VscodeFileReader(),
+    serverUrl
+  );
   return sharedPlutoManager;
 }
 

--- a/src/plutoManagerTypes.ts
+++ b/src/plutoManagerTypes.ts
@@ -1,0 +1,23 @@
+/**
+ * Abstraction for starting/stopping the Pluto server process.
+ * VSCode uses PlutoServerTaskManager (vscode.Task-based).
+ * The CLI uses NodeServerManager (child_process-based).
+ */
+export interface IPlutoServerManager {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  isRunning(): boolean;
+  waitForReady(): Promise<void>;
+  onStop(callback: () => void): void;
+  onPortChanged(callback: (newPort: number) => void): void;
+  getActualPort(): number;
+  getServerUrl(): string;
+}
+
+/**
+ * Abstraction for reading a file by its filesystem path.
+ * VSCode uses vscode.workspace.fs; the CLI uses fs/promises.
+ */
+export interface IFileReader {
+  readFile(path: string): Promise<string>;
+}

--- a/src/vscodeFileReader.ts
+++ b/src/vscodeFileReader.ts
@@ -1,0 +1,10 @@
+import * as vscode from "vscode";
+import type { IFileReader } from "./plutoManagerTypes.ts";
+
+export class VscodeFileReader implements IFileReader {
+  async readFile(path: string): Promise<string> {
+    const uri = vscode.Uri.file(path);
+    const bytes = await vscode.workspace.fs.readFile(uri);
+    return new TextDecoder().decode(bytes);
+  }
+}


### PR DESCRIPTION
## Summary

- Add `@plutojl/cli` — a command-line tool for Pluto.jl notebooks, publishable to npm and runnable with `npx @plutojl/cli` (package lives at `packages/advanced-pluto-mcp/`)
- `run` starts a Pluto server plus a tool server; `tools` / `call` drive notebooks straight from the terminal (open notebooks, create/edit/execute cells, read outputs)
- The tool server also speaks MCP, so AI assistants (Claude Code, Copilot) can connect to the same tools; `install` writes the MCP config for them
- Refactor `PlutoManager` to use dependency injection (`IPlutoServerManager` + `IFileReader` interfaces) so both VSCode and plain Node.js contexts share one implementation
- Add `NodeServerManager` — a `child_process`-based server manager with juliaup fallback, JuliaHub auth, and automatic Pluto setup
- Add tools: `save_notebook`, `delete_cell`, `list_cells`, `get_notebook_url`, `move_cells`, `fold_cell`, `move_notebook`
- Add independent CI and semantic-release workflows with `mcp-v*` tag format

## Architecture

```
root package.json (advanced-vscode-extension)
├── src/plutoManagerTypes.ts    ← IPlutoServerManager + IFileReader interfaces
├── src/plutoManager.ts         ← now uses DI, no vscode import
├── src/vscodeFileReader.ts     ← VSCode IFileReader impl
├── src/cli/                    ← all CLI source (nodeServerManager, run, call, install, etc.)
└── packages/advanced-pluto-mcp/
    ├── package.json            ← npm package "@plutojl/cli"
    ├── esbuild.mjs             ← bundles src/cli/ → dist/cli.cjs
    └── .releaserc.json         ← independent versioning (mcp-v* tags)
```

## Test plan

- [x] `npm run check-types`, `npm run lint`, `npm run compile` pass
- [x] Sub-package build produces executable `dist/cli.cjs` with shebang
- [x] `npx @plutojl/cli --help` prints usage
- [x] `npx @plutojl/cli install --dry-run` outputs correct `.mcp.json` format
- [x] `npx @plutojl/cli run` starts Pluto + tool server, health endpoint responds
- [x] `tools` / `call` work against a running server
- [x] Unit tests pass (51/51 locally with Pluto installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
