### PR TITLE
fix: harden concurrency across PlutoManager, @plutojl/cli, and the extension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,13 +72,14 @@ Press `F5` in VSCode to launch Extension Development Host window for testing.
 - Supports both spawned server and VSCode task-based server
 - Shared between extension and MCP server for consistent state
 
-**MCP HTTP Server** (`src/mcpHttpServer.ts`)
+**MCP HTTP Server** (`src/mcp-server-http.ts`)
 
 - HTTP-based MCP server for AI assistant integration
-- 12 tools for notebook management and code execution
+- Notebook management and code execution tools (see `packages/advanced-pluto-mcp/README.md` for the full list)
 - Server-Sent Events (SSE) for streaming responses
 - Health check endpoint for monitoring
 - Shared PlutoManager instance with extension
+- Also bundled into the `@plutojl/cli` npm package (`src/cli/`), driven from the terminal via `npx @plutojl/cli run|tools|call`
 
 **Interactive Terminal** (`src/plutoTerminal.ts`)
 
@@ -178,7 +179,7 @@ The extension is functional and includes:
 - Pluto server management with automatic lifecycle handling
 - Real-time cell execution using @plutojl/rainbow
 - Rich output rendering in notebooks and terminal webviews
-- MCP server with 12 tools for AI assistants
+- MCP server with notebook tools for AI assistants, shared with the `@plutojl/cli` command-line tool
 - Interactive terminal with command history
 - Configuration commands for Claude Desktop and GitHub Copilot
 

--- a/src/__tests__/plutoManagerConcurrency.test.ts
+++ b/src/__tests__/plutoManagerConcurrency.test.ts
@@ -1,0 +1,253 @@
+import { jest } from "@jest/globals";
+import { PlutoManager, PlutoManagerLogger } from "../plutoManager.js";
+import type { IPlutoServerManager, IFileReader } from "../plutoManagerTypes.js";
+import { Host, Worker } from "@plutojl/rainbow";
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function createMockLogger(): PlutoManagerLogger {
+  return {
+    showWarningMessage: jest.fn(async () => undefined),
+    showInfoMessage: jest.fn(async () => undefined),
+    showErrorMessage: jest.fn(async () => undefined),
+  };
+}
+
+interface MockServerManager extends IPlutoServerManager {
+  startCalls: number;
+  running: boolean;
+  triggerStop: () => void;
+}
+
+function createMockServerManager(startDelayMs = 20): MockServerManager {
+  let onStopCallback: (() => void) | undefined;
+  const manager: MockServerManager = {
+    startCalls: 0,
+    running: false,
+    triggerStop: () => {
+      manager.running = false;
+      onStopCallback?.();
+    },
+    start: async () => {
+      manager.startCalls++;
+      await delay(startDelayMs);
+      manager.running = true;
+    },
+    stop: async () => {
+      // Like real managers, the process exit fires the stop callback
+      // before stop() resolves
+      manager.triggerStop();
+    },
+    isRunning: () => manager.running,
+    waitForReady: async () => {},
+    onStop: (cb: () => void) => {
+      onStopCallback = cb;
+    },
+    onPortChanged: () => {},
+    getActualPort: () => 1234,
+    getServerUrl: () => "http://localhost:1234",
+  };
+  return manager;
+}
+
+const stubFileReader: IFileReader = {
+  readFile: async () => "### A Pluto.jl notebook ###",
+};
+
+function createFakeWorker(overrides: Partial<Worker> = {}): Worker {
+  return {
+    notebook_id: "fake-notebook-id",
+    connected: true,
+    connect: jest.fn(async () => undefined),
+    shutdown: jest.fn(async () => undefined),
+    moveTo: jest.fn(async () => undefined),
+    ...overrides,
+  } as unknown as Worker;
+}
+
+describe("PlutoManager concurrency", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("start()", () => {
+    it("shares one in-flight start between concurrent callers", async () => {
+      const serverManager = createMockServerManager(30);
+      const manager = new PlutoManager(
+        1234,
+        createMockLogger(),
+        serverManager,
+        stubFileReader
+      );
+
+      await Promise.all([manager.start(), manager.start(), manager.start()]);
+
+      expect(serverManager.startCalls).toBe(1);
+      expect(manager.isConnected()).toBe(true);
+    });
+
+    it("does not start again when the server is already running", async () => {
+      const serverManager = createMockServerManager(1);
+      const manager = new PlutoManager(
+        1234,
+        createMockLogger(),
+        serverManager,
+        stubFileReader
+      );
+
+      await manager.start();
+      await manager.start();
+
+      expect(serverManager.startCalls).toBe(1);
+    });
+
+    it("allows retry after a failed start", async () => {
+      const serverManager = createMockServerManager(1);
+      const originalStart = serverManager.start;
+      let failNext = true;
+      serverManager.start = async () => {
+        serverManager.startCalls++;
+        if (failNext) {
+          failNext = false;
+          throw new Error("boom");
+        }
+        serverManager.running = true;
+      };
+
+      const manager = new PlutoManager(
+        1234,
+        createMockLogger(),
+        serverManager,
+        stubFileReader
+      );
+
+      await expect(manager.start()).rejects.toThrow("boom");
+      await manager.start();
+
+      expect(serverManager.startCalls).toBe(2);
+      void originalStart;
+    });
+  });
+
+  describe("stop()", () => {
+    it("does not warn about unexpected stop during intentional stop", async () => {
+      const serverManager = createMockServerManager(1);
+      const logger = createMockLogger();
+      const manager = new PlutoManager(
+        1234,
+        logger,
+        serverManager,
+        stubFileReader
+      );
+
+      await manager.start();
+      await manager.stop();
+
+      expect(logger.showErrorMessage).not.toHaveBeenCalled();
+    });
+
+    it("warns when the server stops unexpectedly", async () => {
+      const serverManager = createMockServerManager(1);
+      const logger = createMockLogger();
+      const manager = new PlutoManager(
+        1234,
+        logger,
+        serverManager,
+        stubFileReader
+      );
+
+      await manager.start();
+      serverManager.triggerStop();
+
+      expect(logger.showErrorMessage).toHaveBeenCalledWith(
+        expect.stringContaining("stopped unexpectedly"),
+        expect.anything()
+      );
+    });
+  });
+
+  describe("getWorker()", () => {
+    // Non-local server URL skips the unlink/moveTo filesystem step
+    const remoteUrl = "http://10.0.0.99:1234";
+
+    it("shares one in-flight creation between concurrent callers", async () => {
+      const fakeWorker = createFakeWorker();
+      const createWorkerSpy = jest
+        .spyOn(Host.prototype, "createWorker")
+        .mockImplementation(async () => {
+          await delay(30);
+          return fakeWorker;
+        });
+
+      const manager = new PlutoManager(
+        1234,
+        createMockLogger(),
+        createMockServerManager(1),
+        stubFileReader,
+        remoteUrl
+      );
+
+      const [a, b] = await Promise.all([
+        manager.getWorker("/tmp/nb.pluto.jl"),
+        manager.getWorker("/tmp/nb.pluto.jl"),
+      ]);
+
+      expect(createWorkerSpy).toHaveBeenCalledTimes(1);
+      expect(a).toBe(fakeWorker);
+      expect(b).toBe(fakeWorker);
+      expect(manager.getOpenNotebooks()).toHaveLength(1);
+    });
+
+    it("creates separate workers for different notebooks", async () => {
+      jest
+        .spyOn(Host.prototype, "createWorker")
+        .mockImplementation(async () => createFakeWorker());
+
+      const manager = new PlutoManager(
+        1234,
+        createMockLogger(),
+        createMockServerManager(1),
+        stubFileReader,
+        remoteUrl
+      );
+
+      const [a, b] = await Promise.all([
+        manager.getWorker("/tmp/one.pluto.jl"),
+        manager.getWorker("/tmp/two.pluto.jl"),
+      ]);
+
+      expect(a).not.toBe(b);
+      expect(manager.getOpenNotebooks()).toHaveLength(2);
+    });
+
+    it("shuts down the worker and allows retry when connect fails", async () => {
+      const failing = createFakeWorker({
+        connect: jest.fn(async () => {
+          throw new Error("no route");
+        }),
+      } as Partial<Worker>);
+      const working = createFakeWorker();
+      const createWorkerSpy = jest
+        .spyOn(Host.prototype, "createWorker")
+        .mockResolvedValueOnce(failing)
+        .mockResolvedValueOnce(working);
+
+      const manager = new PlutoManager(
+        1234,
+        createMockLogger(),
+        createMockServerManager(1),
+        stubFileReader,
+        remoteUrl
+      );
+
+      await expect(manager.getWorker("/tmp/nb.pluto.jl")).rejects.toThrow(
+        "no route"
+      );
+      expect(failing.shutdown).toHaveBeenCalled();
+
+      const worker = await manager.getWorker("/tmp/nb.pluto.jl");
+      expect(worker).toBe(working);
+      expect(createWorkerSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/cli/call.ts
+++ b/src/cli/call.ts
@@ -22,7 +22,8 @@ interface JsonRpcResponse {
 async function mcpRequest(
   port: number,
   method: string,
-  params: Record<string, unknown> = {}
+  params: Record<string, unknown> = {},
+  timeoutMs = 30000
 ): Promise<JsonRpcResponse["result"]> {
   const sseUrl = `http://localhost:${port}/mcp`;
 
@@ -112,9 +113,11 @@ async function mcpRequest(
 
   // 4. Read SSE events until we get our response
   buffer = "";
+  let timedOut = false;
   const timeout = setTimeout(() => {
+    timedOut = true;
     reader.cancel().catch(() => {});
-  }, 30000);
+  }, timeoutMs);
 
   try {
     while (true) {
@@ -156,6 +159,12 @@ async function mcpRequest(
     reader.cancel().catch(() => {});
   }
 
+  if (timedOut) {
+    throw new Error(
+      `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for ${method}. ` +
+        `The operation may still be running on the server — pass --timeout <seconds> to wait longer.`
+    );
+  }
   throw new Error("No response received from MCP server");
 }
 
@@ -185,7 +194,8 @@ export async function callTool(
   port: number,
   toolName: string,
   argsJson: string,
-  raw: boolean
+  raw: boolean,
+  timeoutMs = 120000
 ): Promise<void> {
   let args: Record<string, unknown>;
   try {
@@ -195,10 +205,15 @@ export async function callTool(
     process.exit(1);
   }
 
-  const result = await mcpRequest(port, "tools/call", {
-    name: toolName,
-    arguments: args,
-  });
+  const result = await mcpRequest(
+    port,
+    "tools/call",
+    {
+      name: toolName,
+      arguments: args,
+    },
+    timeoutMs
+  );
 
   if (raw) {
     console.log(JSON.stringify(result, null, 2));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,14 +1,17 @@
 import { parseArgs } from "./parseArgs.ts";
-import { resolveRunConfig, resolveInstallArgs } from "./resolveConfig.ts";
+import {
+  resolveRunConfig,
+  resolveInstallArgs,
+  resolveMcpPort,
+} from "./resolveConfig.ts";
 import { run } from "./run.ts";
 import { installMcpConfig } from "./install.ts";
 import { callTool, listTools } from "./call.ts";
 import { preflight } from "./preflight.ts";
-import { DEFAULTS } from "./config.ts";
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const mcpPort = args.mcpPort ?? DEFAULTS.mcpPort;
+  const mcpPort = resolveMcpPort(args);
 
   switch (args.command) {
     case "run": {
@@ -36,7 +39,8 @@ async function main() {
         mcpPort,
         args.toolName,
         args.toolArgs ?? "{}",
-        args.raw ?? false
+        args.raw ?? false,
+        (args.timeoutSeconds ?? 120) * 1000
       );
       break;
     }

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -56,8 +56,10 @@ function installClaudeCode(
     return;
   }
 
+  // The tool server speaks the SSE transport (GET /mcp + POST /messages),
+  // not streamable HTTP — the config type must match
   mcpServers["pluto-notebook"] = {
-    type: "http",
+    type: "sse",
     url: `http://localhost:${mcpPort}/mcp`,
   };
 
@@ -83,7 +85,7 @@ function installCopilot(
 
   servers["pluto-notebook"] = {
     url: `http://localhost:${mcpPort}/mcp`,
-    type: "http",
+    type: "sse",
   };
 
   existing.servers = servers;
@@ -110,6 +112,6 @@ export async function installMcpConfig(args: InstallArgs): Promise<void> {
   }
 
   if (!args.dryRun) {
-    console.log("Done! Start the MCP server with: npx @plutojl/cli run");
+    console.log("Done! Start the tool server with: npx @plutojl/cli run");
   }
 }

--- a/src/cli/nodeServerManager.ts
+++ b/src/cli/nodeServerManager.ts
@@ -1,10 +1,27 @@
-import { spawn, spawnSync, type ChildProcess } from "child_process";
+import { spawn, type ChildProcess, type SpawnOptions } from "child_process";
 import * as os from "os";
 import * as path from "path";
 import * as fs from "fs";
 import type { IPlutoServerManager } from "../plutoManagerTypes.ts";
 import { isPortAvailable, findAvailablePort } from "../portUtils.ts";
 import { getExecutableName, isWindows } from "../platformUtils.ts";
+
+/**
+ * Run a child process to completion without blocking the event loop
+ * (unlike spawnSync — the MCP health endpoint must stay responsive
+ * while Julia setup runs).
+ */
+function runProcess(
+  command: string,
+  args: string[],
+  options: SpawnOptions
+): Promise<{ status: number | null; error?: Error }> {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, options);
+    child.on("error", (error) => resolve({ status: null, error }));
+    child.on("exit", (code) => resolve({ status: code }));
+  });
+}
 
 export class NodeServerManager implements IPlutoServerManager {
   private juliaProcess?: ChildProcess;
@@ -69,27 +86,28 @@ export class NodeServerManager implements IPlutoServerManager {
 
       // 2. Check Julia is available
       const juliaCmd = getExecutableName("julia");
-      const juliaCheck = spawnSync(juliaCmd, ["--version"], {
+      const juliaCheck = await runProcess(juliaCmd, ["--version"], {
         stdio: "pipe",
         timeout: 10000,
       });
       if (juliaCheck.error) {
-        console.error(
-          "Error: Julia not found. Please install Julia from https://julialang.org/downloads/"
+        throw new Error(
+          "Julia not found. Please install Julia from https://julialang.org/downloads/ " +
+            "or install juliaup from https://github.com/JuliaLang/juliaup#installation"
         );
-        console.error(
-          "  or install juliaup from https://github.com/JuliaLang/juliaup#installation"
-        );
-        process.exit(1);
       }
 
       // 3. Try juliaup to ensure the requested version is available
       let useJuliaupPrefix = true;
       const juliaupCmd = getExecutableName("juliaup");
-      const juliaupResult = spawnSync(juliaupCmd, ["add", this.juliaVersion], {
-        stdio: "pipe",
-        timeout: 60000,
-      });
+      const juliaupResult = await runProcess(
+        juliaupCmd,
+        ["add", this.juliaVersion],
+        {
+          stdio: "pipe",
+          timeout: 60000,
+        }
+      );
       if (juliaupResult.error) {
         console.log(
           "[pluto] juliaup not found — using system julia (ignoring --julia-version)"
@@ -116,7 +134,7 @@ export class NodeServerManager implements IPlutoServerManager {
       }
 
       // 6. Optional JuliaHub auth
-      this.tryJuliaHubAuth(env, juliaCmd, juliaArgs);
+      await this.tryJuliaHubAuth(env, juliaCmd, juliaArgs);
 
       // 7. Setup task — install Pluto if needed
       console.log(
@@ -133,11 +151,18 @@ export class NodeServerManager implements IPlutoServerManager {
         "Pkg.precompile()",
       ].join(";");
 
-      const setupResult = spawnSync(juliaCmd, [...juliaArgs, "-e", setupCode], {
-        stdio: "inherit",
-        env,
-        timeout: 600000,
-      });
+      const setupResult = await runProcess(
+        juliaCmd,
+        [...juliaArgs, "-e", setupCode],
+        {
+          stdio: "inherit",
+          env,
+          timeout: 600000,
+        }
+      );
+      if (setupResult.error) {
+        throw new Error(`Julia setup failed: ${setupResult.error.message}`);
+      }
       if (setupResult.status !== 0) {
         throw new Error(
           `Julia setup failed with exit code ${setupResult.status}`
@@ -218,11 +243,11 @@ export class NodeServerManager implements IPlutoServerManager {
     this.actualPort = this.port;
   }
 
-  private tryJuliaHubAuth(
+  private async tryJuliaHubAuth(
     env: Record<string, string>,
     juliaCmd: string,
     juliaArgs: string[]
-  ): void {
+  ): Promise<void> {
     try {
       const jhCmd = getExecutableName("jh");
       const tmpFile = path.join(
@@ -243,7 +268,7 @@ export class NodeServerManager implements IPlutoServerManager {
         `end`,
       ].join(";");
 
-      const result = spawnSync(juliaCmd, [...juliaArgs, "-e", script], {
+      const result = await runProcess(juliaCmd, [...juliaArgs, "-e", script], {
         env: { ...env, VSCODE_PLUTO_AUTH_FILE: tmpFile },
         stdio: "pipe",
         timeout: 15000,
@@ -271,9 +296,6 @@ export class NodeServerManager implements IPlutoServerManager {
   }
 
   private async pollServerReady(): Promise<void> {
-    // Initial wait for Julia to start up
-    await new Promise((r) => setTimeout(r, 5000));
-
     const maxAttempts = 120;
     const pollInterval = 1000;
 

--- a/src/cli/nodeServerManager.ts
+++ b/src/cli/nodeServerManager.ts
@@ -18,6 +18,10 @@ function runProcess(
 ): Promise<{ status: number | null; error?: Error }> {
   return new Promise((resolve) => {
     const child = spawn(command, args, options);
+    // Drain piped output — an undrained pipe blocks the child once the
+    // OS buffer (~64KB) fills, which spawnSync's buffering used to hide
+    child.stdout?.resume();
+    child.stderr?.resume();
     child.on("error", (error) => resolve({ status: null, error }));
     child.on("exit", (code) => resolve({ status: code }));
   });

--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -17,6 +17,7 @@ export interface RawArgs {
   toolName?: string;
   toolArgs?: string;
   raw?: boolean;
+  timeoutSeconds?: number;
 }
 
 function printHelp(): void {
@@ -50,6 +51,7 @@ Call options:
   npx @plutojl/cli call <tool_name> [json_args]
   --mcp-port <port>        MCP server port (default: ${DEFAULTS.mcpPort})
   --raw                    Output raw JSON response
+  --timeout <seconds>      Wait this long for the tool result (default: 120)
 
 Tools options:
   --mcp-port <port>        MCP server port (default: ${DEFAULTS.mcpPort})
@@ -61,7 +63,7 @@ Examples:
   npx @plutojl/cli install --target all --global
   npx @plutojl/cli tools
   npx @plutojl/cli call get_notebook_status
-  npx @plutojl/cli call start_pluto_server '{"port": 1234}'
+  npx @plutojl/cli call start_pluto_server
   npx @plutojl/cli call open_notebook '{"path": "/tmp/nb.pluto.jl"}'
 `);
 }
@@ -146,6 +148,13 @@ export function parseArgs(argv: string[]): RawArgs {
       args.force = true;
     } else if (flag === "--raw") {
       args.raw = true;
+    } else if (flag === "--timeout" && i + 1 < argv.length) {
+      const seconds = parseInt(argv[++i], 10);
+      if (isNaN(seconds) || seconds <= 0) {
+        console.error(`Invalid --timeout value: ${argv[i]}`);
+        process.exit(1);
+      }
+      args.timeoutSeconds = seconds;
     } else if (flag === "--no-pluto") {
       args.noPluto = true;
     } else {

--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -148,10 +148,11 @@ export function parseArgs(argv: string[]): RawArgs {
       args.force = true;
     } else if (flag === "--raw") {
       args.raw = true;
-    } else if (flag === "--timeout" && i + 1 < argv.length) {
-      const seconds = parseInt(argv[++i], 10);
+    } else if (flag === "--timeout") {
+      const value = argv[++i];
+      const seconds = value === undefined ? NaN : parseInt(value, 10);
       if (isNaN(seconds) || seconds <= 0) {
-        console.error(`Invalid --timeout value: ${argv[i]}`);
+        console.error(`Invalid --timeout value: ${value ?? "(missing)"}`);
         process.exit(1);
       }
       args.timeoutSeconds = seconds;

--- a/src/cli/preflight.ts
+++ b/src/cli/preflight.ts
@@ -50,9 +50,7 @@ export async function preflight(
     console.error(``);
     console.error(`Or connect to an existing Pluto server:`);
     console.error(``);
-    console.error(
-      `  npx @plutojl/cli call connect_to_pluto_server '{"port": 1234}'`
-    );
+    console.error(`  npx @plutojl/cli call connect_to_pluto_server`);
     process.exit(1);
   }
 

--- a/src/cli/resolveConfig.ts
+++ b/src/cli/resolveConfig.ts
@@ -58,6 +58,14 @@ export function resolveRunConfig(args: RawArgs): CliConfig {
   };
 }
 
+/** MCP port resolution shared by run/install/tools/call: CLI arg > env > .plutomcp.json > default */
+export function resolveMcpPort(args: RawArgs): number {
+  const file = loadConfigFile(process.cwd());
+  return (
+    args.mcpPort ?? envInt("PLUTO_MCP_PORT") ?? file.mcpPort ?? DEFAULTS.mcpPort
+  );
+}
+
 export function resolveInstallArgs(args: RawArgs): InstallArgs {
   return {
     target: args.target ?? "claude-code",

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -24,7 +24,7 @@ export async function run(config: CliConfig): Promise<void> {
   );
 
   // Start the MCP HTTP server first (so health endpoint is available during Pluto startup)
-  const mcpServer = new PlutoMCPHttpServer(plutoManager, config.mcpPort, true);
+  const mcpServer = new PlutoMCPHttpServer(plutoManager, config.mcpPort);
   await mcpServer.start();
 
   console.log(
@@ -63,8 +63,14 @@ export async function run(config: CliConfig): Promise<void> {
   console.log(`\n[cli] Press Ctrl+C to stop\n`);
   console.log(`Tip: Run 'npx @plutojl/cli install' to configure Claude Code\n`);
 
-  // Graceful shutdown
+  // Graceful shutdown — owns both signals; guard against a second signal
+  // arriving while shutdown is already in progress
+  let shuttingDown = false;
   const shutdown = async () => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
     console.log("\n[cli] Shutting down...");
     try {
       await mcpServer.stop();
@@ -79,5 +85,6 @@ export async function run(config: CliConfig): Promise<void> {
     process.exit(0);
   };
 
+  process.on("SIGINT", () => void shutdown());
   process.on("SIGTERM", () => void shutdown());
 }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -64,13 +64,10 @@ export class PlutoNotebookController {
     const worker = await this.plutoManager.getWorker(notebook.uri.fsPath);
     if (worker) {
       try {
-        // Find all currently running executions and mark them as failed
-        for (const [cellId, execution] of this.activeExecutions.entries()) {
-          execution.end(false, Date.now());
-          this.activeExecutions.delete(cellId);
-        }
-
         await worker.interrupt();
+        // End this notebook's executions only after the interrupt landed —
+        // ending them earlier lets late patches resurrect them as successes
+        this.endExecutionsForNotebook(notebook);
         vscode.window.showInformationMessage("Notebook execution interrupted");
       } catch (error) {
         this.outputChannel.appendLine(`Error interrupting notebook: ${error}`);
@@ -78,6 +75,24 @@ export class PlutoNotebookController {
       }
     }
   };
+
+  /**
+   * End (as failed) all active executions belonging to one notebook.
+   * Executions of other notebooks are left untouched.
+   */
+  private endExecutionsForNotebook(notebook: vscode.NotebookDocument): void {
+    const cellsById = this.getCodeCellRecord(notebook);
+    for (const [cellId, execution] of this.activeExecutions.entries()) {
+      if (cellsById[cellId]) {
+        try {
+          execution.end(false, Date.now());
+        } catch {
+          // Execution may already be resolved
+        }
+        this.activeExecutions.delete(cellId);
+      }
+    }
+  }
 
   constructor(
     private readonly plutoManager: PlutoManager,
@@ -98,10 +113,30 @@ export class PlutoNotebookController {
     this.setupMessaging();
 
     // Listen for worker recreation after server restart
-    this.plutoManager.on("workerRecreated", (notebookPath, worker) => {
-      this.handleWorkerRecreated(notebookPath, worker);
-    });
+    this.plutoManager.on("workerRecreated", this.onWorkerRecreated);
+
+    // When the server goes away, no more patches will arrive — end all
+    // in-flight executions instead of letting them spin forever
+    this.plutoManager.on("serverStateChanged", this.onServerStateChanged);
   }
+
+  private onWorkerRecreated = (notebookPath: string, worker: Worker): void => {
+    this.handleWorkerRecreated(notebookPath, worker);
+  };
+
+  private onServerStateChanged = (): void => {
+    if (this.plutoManager.isConnected()) {
+      return;
+    }
+    for (const execution of this.activeExecutions.values()) {
+      try {
+        execution.end(false, Date.now());
+      } catch {
+        // Execution may already be resolved
+      }
+    }
+    this.activeExecutions.clear();
+  };
 
   /**
    * Setup communication bridge between controller and renderer
@@ -239,6 +274,9 @@ export class PlutoNotebookController {
     );
 
     if (notebook) {
+      // Executions tied to the dead worker will never receive their
+      // end patches — fail them before resubscribing
+      this.endExecutionsForNotebook(notebook);
       this.subscribeToWorker(notebookPath, notebook, worker);
     } else {
       this.outputChannel.appendLine(
@@ -250,10 +288,14 @@ export class PlutoNotebookController {
   private startExecution(
     cellId: CellId,
     notebook: vscode.NotebookDocument
-  ): { execution: vscode.NotebookCellExecution; cell: vscode.NotebookCell } {
+  ):
+    | { execution: vscode.NotebookCellExecution; cell: vscode.NotebookCell }
+    | undefined {
+    // Cells created outside VSCode (ephemeral terminal cells, MCP
+    // create_cell) have no notebook counterpart — callers skip them
     const cell = this.getCellByPlutoId(notebook, cellId);
     if (!cell) {
-      throw new Error("Can not determine notebook cell");
+      return undefined;
     }
     let execution = this.activeExecutions.get(cellId);
 
@@ -280,6 +322,20 @@ export class PlutoNotebookController {
     const cellId = path[1] as CellId;
 
     const currentCellState = fullNotebookState.cell_results[cellId];
+    if (!currentCellState) {
+      // Patch for a cell that no longer exists (remove op, or an
+      // ephemeral cell already deleted) — end any leftover execution
+      const execution = this.activeExecutions.get(cellId);
+      if (execution) {
+        try {
+          execution.end(false, Date.now());
+        } catch {
+          // Execution may already be resolved
+        }
+        this.activeExecutions.delete(cellId);
+      }
+      return;
+    }
 
     const body = currentCellState.output?.body;
     try {
@@ -326,16 +382,21 @@ export class PlutoNotebookController {
     }
     if (isStarting) {
       // Start execution
-      const { execution } = this.startExecution(cellId, notebook);
-      const formatted = formatCellOutput(currentCellState);
-      execution.replaceOutput([formatted]);
+      const started = this.startExecution(cellId, notebook);
+      if (started) {
+        const formatted = formatCellOutput(currentCellState);
+        started.execution.replaceOutput([formatted]);
+      }
     }
 
     // 2. Update Cell Output (only if an execution object exists)
     if (segment2 === "output") {
       // Handle final output/result update
-      const { execution, cell } = this.startExecution(cellId, notebook);
-      // execution.replaceOutput([formatCellOutput(currentCellState)]);
+      const started = this.startExecution(cellId, notebook);
+      if (!started) {
+        return;
+      }
+      const { execution, cell } = started;
 
       this.outputChannel.appendLine(
         `[OUTPUT] Cell ${cellId} for notebook ${notebook.uri} output updated.`
@@ -346,7 +407,7 @@ export class PlutoNotebookController {
       if (cell.outputs.length === 0) {
         execution.replaceOutput([formatCellOutput(currentCellState)]);
       }
-      execution.end(true, Date.now());
+      execution.end(!currentCellState.errored, Date.now());
       this.activeExecutions.delete(cellId);
       this.outputChannel.appendLine(`[EXEC END] Cell ${cellId} finished.`);
     } else if (segment2 === "logs") {
@@ -467,7 +528,11 @@ export class PlutoNotebookController {
       fullNotebookState?.cell_results ?? {}
     )) {
       const start = Date.now();
-      const { execution } = this.startExecution(cell_id, notebook);
+      const started = this.startExecution(cell_id, notebook);
+      if (!started) {
+        continue;
+      }
+      const { execution } = started;
       try {
         await execution.replaceOutput([formatCellOutput(state)]);
       } catch (e) {
@@ -511,7 +576,15 @@ export class PlutoNotebookController {
           const [action, ...rest] = path;
           if (path.length === 0 && patches.length === 1) {
             // This is a state reset; handle it accordingly and break
-            this.updateAllCellsFromState(notebook, event);
+            void this.updateAllCellsFromState(notebook, event).catch(
+              (error) => {
+                this.outputChannel.appendLine(
+                  `Failed to reset cells from state: ${
+                    error instanceof Error ? error.message : String(error)
+                  }`
+                );
+              }
+            );
             break;
           }
           switch (action) {
@@ -538,7 +611,17 @@ export class PlutoNotebookController {
               break;
             }
             case "cell_results":
-              this._handleCellPatch(notebook, patch, fullNotebookState);
+              // Isolate per-patch failures so one bad patch doesn't drop
+              // the remaining cells' updates from the same batch
+              try {
+                this._handleCellPatch(notebook, patch, fullNotebookState);
+              } catch (error) {
+                this.outputChannel.appendLine(
+                  `Failed to apply cell patch for ${patch.path.join(".")}: ${
+                    error instanceof Error ? error.message : String(error)
+                  }`
+                );
+              }
               break;
             case "process_status":
               this.outputChannel.appendLine(
@@ -652,6 +735,17 @@ export class PlutoNotebookController {
 
         this.outputChannel.appendLine(`Cell added with ID: ${cellId}`);
 
+        // Recompute the index — the notebook may have changed during the
+        // round trip, and a stale index would tag the wrong cell
+        const currentIndex = notebook.getCells().indexOf(addedCell);
+        if (currentIndex === -1) {
+          this.outputChannel.appendLine(
+            `Cell removed while being added — deleting ${cellId} from Pluto`
+          );
+          await this.plutoManager.deleteCell(worker, cellId);
+          continue;
+        }
+
         // Update the cell's metadata with the Pluto cell ID
         const edit = new vscode.WorkspaceEdit();
         const cellMetadata = {
@@ -660,7 +754,7 @@ export class PlutoNotebookController {
         };
 
         edit.set(notebook.uri, [
-          vscode.NotebookEdit.updateCellMetadata(cellIndex, cellMetadata),
+          vscode.NotebookEdit.updateCellMetadata(currentIndex, cellMetadata),
         ]);
 
         await vscode.workspace.applyEdit(edit);
@@ -754,10 +848,48 @@ export class PlutoNotebookController {
     }
   }
 
-  public async dispose(): Promise<void> {
+  /**
+   * Stop tracking a closed notebook: drop its worker subscription and end
+   * its executions. The worker itself stays alive — MCP clients and
+   * Pluto's own UI may still be using the notebook.
+   */
+  public handleNotebookClosed(notebook: vscode.NotebookDocument): void {
+    if (notebook.notebookType !== "pluto-notebook") {
+      return;
+    }
+    const notebookPath = notebook.uri.fsPath;
+    const unsubscribe = this.workerSubscriptions.get(notebookPath);
+    if (unsubscribe) {
+      unsubscribe();
+      this.workerSubscriptions.delete(notebookPath);
+      this.outputChannel.appendLine(
+        `[SUBSCRIPTION] Unsubscribed from closed notebook ${notebookPath}`
+      );
+    }
+    this.endExecutionsForNotebook(notebook);
+  }
+
+  public dispose(): void {
+    this.plutoManager.off("workerRecreated", this.onWorkerRecreated);
+    this.plutoManager.off("serverStateChanged", this.onServerStateChanged);
+
+    for (const unsubscribe of this.workerSubscriptions.values()) {
+      unsubscribe();
+    }
+    this.workerSubscriptions.clear();
+
+    for (const execution of this.activeExecutions.values()) {
+      try {
+        execution.end(false, Date.now());
+      } catch {
+        // Execution may already be resolved
+      }
+    }
+    this.activeExecutions.clear();
+
     this.controller.dispose();
-    // NotebookRendererMessaging doesn't have a dispose method
-    await this.plutoManager.dispose();
+    // The shared PlutoManager is disposed by the extension's subscriptions,
+    // not here — the MCP server may outlive this controller.
   }
 
   private async _doExecution(
@@ -775,7 +907,14 @@ export class PlutoNotebookController {
     }
 
     // Ensure there is at least an initial execution object for this cell
-    const { execution } = this.startExecution(cellId, notebook);
+    const started = this.startExecution(cellId, notebook);
+    if (!started) {
+      vscode.window.showErrorMessage(
+        `Cell ${cellId} not found in notebook — cannot execute`
+      );
+      return;
+    }
+    const { execution } = started;
 
     try {
       // Get or create worker - this will start the server if needed

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -65,13 +65,16 @@ export class PlutoNotebookController {
     if (worker) {
       try {
         await worker.interrupt();
-        // End this notebook's executions only after the interrupt landed —
-        // ending them earlier lets late patches resurrect them as successes
-        this.endExecutionsForNotebook(notebook);
         vscode.window.showInformationMessage("Notebook execution interrupted");
       } catch (error) {
         this.outputChannel.appendLine(`Error interrupting notebook: ${error}`);
         vscode.window.showErrorMessage("Failed to interrupt execution");
+      } finally {
+        // End this notebook's executions after the interrupt attempt —
+        // waiting until now stops late patches from resurrecting them as
+        // successes, and a failed interrupt must still release the
+        // spinners (a still-running kernel will just re-create them)
+        this.endExecutionsForNotebook(notebook);
       }
     }
   };
@@ -949,14 +952,21 @@ export class PlutoNotebookController {
         error instanceof Error ? error.message : String(error);
       this.outputChannel.appendLine(`Error executing cell: ${errorMessage}`);
 
-      // If an error occurred BEFORE even talking to the kernel, we end the execution immediately.
-      execution?.replaceOutput([
-        new vscode.NotebookCellOutput([
-          vscode.NotebookCellOutputItem.error(error as Error),
-        ]),
-      ]);
-      execution?.end(false, Date.now());
-      this.activeExecutions.delete(cellId);
+      // If an error occurred BEFORE even talking to the kernel, we end the
+      // execution immediately — unless a streaming patch already ended it
+      if (this.activeExecutions.get(cellId) === execution) {
+        try {
+          execution.replaceOutput([
+            new vscode.NotebookCellOutput([
+              vscode.NotebookCellOutputItem.error(error as Error),
+            ]),
+          ]);
+          execution.end(false, Date.now());
+        } catch {
+          // Execution may already be resolved
+        }
+        this.activeExecutions.delete(cellId);
+      }
 
       // Show error notification for critical failures
       if (errorMessage.includes("server") || errorMessage.includes("worker")) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,10 @@ import {
   registerAllCommands,
   initializePlutoServer,
 } from "./commands/index.ts";
-import { getSharedPlutoManager } from "./plutoManagerInstance.ts";
+import {
+  getSharedPlutoManager,
+  clearSharedPlutoManager,
+} from "./plutoManagerInstance.ts";
 import {
   initializeMCPServer,
   startMCPServer,
@@ -44,13 +47,25 @@ export async function activate(
     serverUrl || undefined
   );
   context.subscriptions.push(plutoManager);
+  context.subscriptions.push({ dispose: () => clearSharedPlutoManager() });
 
   // Initialize HTTP MCP Server using the shared PlutoManager (singleton)
   initializeMCPServer(plutoManager, mcpPort, controllerOutputChannel);
 
-  // Auto-start MCP server if configured
+  // Auto-start MCP server if configured. A failure (e.g. port in use by
+  // another VSCode window) must not prevent the extension from activating.
   if (autoStartMcp) {
-    await startMCPServer(controllerOutputChannel);
+    try {
+      await startMCPServer(controllerOutputChannel);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      controllerOutputChannel.appendLine(
+        `MCP server failed to start (continuing without it): ${message}`
+      );
+      vscode.window.showWarningMessage(
+        `Pluto: MCP server failed to start on port ${mcpPort} (${message}). Notebooks still work; MCP clients won't connect to this window.`
+      );
+    }
   }
 
   // Ensure MCP server is stopped and cleaned up when extension deactivates
@@ -60,9 +75,6 @@ export async function activate(
       cleanupMCPServer();
     },
   });
-
-  // Start Pluto server on activation
-  await initializePlutoServer(plutoManager, controllerOutputChannel);
 
   // Register the notebook serializer
   context.subscriptions.push(
@@ -96,12 +108,39 @@ export async function activate(
   // Handle notebook cell changes (add/delete cells)
   context.subscriptions.push(
     vscode.workspace.onDidChangeNotebookDocument(async (event) => {
-      await controller.handleVsCodeNotebookChange(event);
+      try {
+        await controller.handleVsCodeNotebookChange(event);
+      } catch (error) {
+        controllerOutputChannel.appendLine(
+          `Failed to handle notebook change: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+    })
+  );
+
+  // Stop tracking notebooks when their document closes
+  context.subscriptions.push(
+    vscode.workspace.onDidCloseNotebookDocument((notebook) => {
+      controller.handleNotebookClosed(notebook);
     })
   );
 
   // Register all commands
   registerAllCommands(context, plutoManager);
+
+  // Start Pluto server in the background — activation must not block on
+  // (potentially minutes of) first-run Julia setup
+  void initializePlutoServer(plutoManager, controllerOutputChannel).catch(
+    (error) => {
+      controllerOutputChannel.appendLine(
+        `Pluto server autostart failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  );
 
   // Create and register status bar
   const statusBar = new PlutoStatusBar(plutoManager);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -131,16 +131,24 @@ export async function activate(
   registerAllCommands(context, plutoManager);
 
   // Start Pluto server in the background — activation must not block on
-  // (potentially minutes of) first-run Julia setup
-  void initializePlutoServer(plutoManager, controllerOutputChannel).catch(
-    (error) => {
+  // (potentially minutes of) first-run Julia setup. Once the server is up,
+  // register the notebooks that were already open so they get workers
+  // without requiring a manual cell execution first.
+  void initializePlutoServer(plutoManager, controllerOutputChannel)
+    .then(async () => {
+      for (const notebook of vscode.workspace.notebookDocuments) {
+        if (notebook.notebookType === "pluto-notebook") {
+          await controller.registerNotebookDocument(notebook);
+        }
+      }
+    })
+    .catch((error) => {
       controllerOutputChannel.appendLine(
         `Pluto server autostart failed: ${
           error instanceof Error ? error.message : String(error)
         }`
       );
-    }
-  );
+    });
 
   // Create and register status bar
   const statusBar = new PlutoStatusBar(plutoManager);

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -22,16 +22,13 @@ export class PlutoMCPHttpServer {
   private readonly transports: Map<string, SSEServerTransport> = new Map();
   private readonly plutoManager: PlutoManager;
   private readonly port: number;
-  private readonly handleSignals: boolean;
 
-  constructor(plutoManager: PlutoManager, port = 3100, handleSignals = false) {
+  constructor(plutoManager: PlutoManager, port = 3100) {
     this.plutoManager = plutoManager;
     this.port = port;
-    this.handleSignals = handleSignals;
     this.app = express();
     this.app.use(express.json());
     this.setupRoutes();
-    this.setupErrorHandling();
   }
 
   private createMcpServer(): McpServer {
@@ -1023,17 +1020,6 @@ export class PlutoMCPHttpServer {
     });
   }
 
-  private setupErrorHandling(): void {
-    if (!this.handleSignals) {
-      return;
-    }
-    process.on("SIGINT", async () => {
-      console.log("[MCP HTTP] Shutting down server...");
-      await this.stop();
-      process.exit(0);
-    });
-  }
-
   public async start(): Promise<void> {
     return await new Promise((resolve, reject) => {
       this.httpServer = this.app.listen(this.port, (error?: Error) => {
@@ -1073,13 +1059,20 @@ export class PlutoMCPHttpServer {
       }
     }
 
-    // Close HTTP server
+    // Close HTTP server (resolve immediately if it never started)
     await new Promise<void>((resolve) => {
-      this.httpServer?.close(() => {
+      if (!this.httpServer) {
+        resolve();
+        return;
+      }
+      this.httpServer.close(() => {
         console.log("[MCP HTTP] HTTP server closed");
         resolve();
       });
+      // Idle keep-alive connections would otherwise hold close() open
+      this.httpServer.closeIdleConnections();
     });
+    this.httpServer = undefined;
   }
 
   public getPort(): number {

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -71,21 +71,15 @@ export class PlutoMCPHttpServer {
     // Start Pluto Server
     server.tool(
       "start_pluto_server",
-      "Start the Pluto server on a specified port",
-      {
-        port: z
-          .number()
-          .describe("Port number for the Pluto server")
-          .optional()
-          .default(1234),
-      },
-      async ({ port }) => {
+      "Start the Pluto server on the configured port (set via --pluto-port or extension settings)",
+      {},
+      async () => {
         if (this.plutoManager.isRunning()) {
           return {
             content: [
               {
                 type: "text",
-                text: "Pluto server is already running",
+                text: `Pluto server is already running at ${this.plutoManager.getServerUrl()}`,
               },
             ],
           };
@@ -96,7 +90,7 @@ export class PlutoMCPHttpServer {
           content: [
             {
               type: "text",
-              text: `Pluto server started on port ${port}`,
+              text: `Pluto server started at ${this.plutoManager.getServerUrl()}`,
             },
           ],
         };
@@ -106,21 +100,15 @@ export class PlutoMCPHttpServer {
     // Connect to Pluto Server
     server.tool(
       "connect_to_pluto_server",
-      "Connect to an existing Pluto server (assumes server is already running)",
-      {
-        port: z
-          .number()
-          .describe("Port number of the running Pluto server")
-          .optional()
-          .default(1234),
-      },
-      async ({ port }) => {
+      "Connect to an already-running Pluto server at the configured URL (set via --pluto-url or extension settings)",
+      {},
+      async () => {
         if (this.plutoManager.isConnected()) {
           return {
             content: [
               {
                 type: "text",
-                text: "Already connected to a Pluto server",
+                text: `Already connected to a Pluto server at ${this.plutoManager.getServerUrl()}`,
               },
             ],
           };
@@ -131,7 +119,7 @@ export class PlutoMCPHttpServer {
           content: [
             {
               type: "text",
-              text: `Connected to Pluto server at port ${port}`,
+              text: `Connected to Pluto server at ${this.plutoManager.getServerUrl()}`,
             },
           ],
         };
@@ -471,6 +459,9 @@ export class PlutoMCPHttpServer {
       {},
       async () => {
         const isConnected = this.plutoManager.isConnected();
+        const notebooks = isConnected
+          ? this.plutoManager.getOpenNotebooks()
+          : [];
 
         return {
           content: [
@@ -479,6 +470,8 @@ export class PlutoMCPHttpServer {
               text: JSON.stringify(
                 {
                   server_running: isConnected,
+                  server_url: this.plutoManager.getServerUrl(),
+                  open_notebooks: notebooks.length,
                   message: isConnected
                     ? "Pluto server is running"
                     : "Pluto server is not running",

--- a/src/plutoManager.ts
+++ b/src/plutoManager.ts
@@ -35,6 +35,9 @@ export interface PlutoManagerLogger {
 export class PlutoManager {
   private host?: Host; // Host from @plutojl/rainbow
   private readonly workers: Map<string, Worker> = new Map(); // notebook_id -> Worker
+  private readonly pendingWorkers: Map<string, Promise<Worker>> = new Map(); // in-flight worker creation, keyed by path
+  private startPromise?: Promise<void>; // in-flight start(), shared by concurrent callers
+  private stopping = false; // suppresses "stopped unexpectedly" handling during intentional stop
   private serverUrl: string;
   private usingCustomServerUrl = false;
   private readonly notebooksToRecreate: Set<string> = new Set(); // Paths of notebooks to recreate after reconnect
@@ -103,8 +106,12 @@ export class PlutoManager {
    * Called when server task stops unexpectedly
    */
   private onServerStopped(): void {
+    if (this.stopping) {
+      // Intentional stop — stop() owns worker shutdown and event emission
+      return;
+    }
+
     // Store notebook paths for recreation after reconnect
-    this.notebooksToRecreate.clear();
     for (const notebookPath of this.workers.keys()) {
       this.notebooksToRecreate.add(notebookPath);
     }
@@ -166,9 +173,17 @@ export class PlutoManager {
   }
 
   /**
-   * Start Pluto server (or connect to custom server URL)
+   * Start Pluto server (or connect to custom server URL).
+   * Concurrent callers share one in-flight start.
    */
   public async start(): Promise<void> {
+    this.startPromise ??= this.doStart().finally(() => {
+      this.startPromise = undefined;
+    });
+    return this.startPromise;
+  }
+
+  private async doStart(): Promise<void> {
     // If using custom server URL, just connect without starting
     if (this.usingCustomServerUrl) {
       await this.connect();
@@ -178,6 +193,8 @@ export class PlutoManager {
 
     // Check if already running
     if (this.serverManager.isRunning()) {
+      await this.serverManager.waitForReady();
+      await this.connect();
       return;
     }
 
@@ -221,33 +238,48 @@ export class PlutoManager {
 
   /**
    * Stop Pluto server. Times out worker shutdown after 10s to avoid hanging.
+   * Open notebooks are remembered and recreated on the next start().
    */
   public async stop(): Promise<void> {
-    // Close all workers with a timeout — don't let a hung worker block shutdown
-    const workerShutdown = Promise.allSettled(
-      [...this.workers.values()].map((worker) =>
-        worker.shutdown().catch(() => {
-          // Worker shutdown can fail if server is already gone — ignore
-        })
-      )
-    );
+    this.stopping = true;
+    try {
+      // Remember open notebooks so the next start() can recreate them
+      for (const notebookPath of this.workers.keys()) {
+        this.notebooksToRecreate.add(notebookPath);
+      }
 
-    const timeoutMs = 10_000;
-    await Promise.race([
-      workerShutdown,
-      new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
-    ]);
-    this.workers.clear();
+      // Close all workers with a timeout — don't let a hung worker block shutdown
+      const workerShutdown = Promise.allSettled(
+        [...this.workers.values()].map((worker) =>
+          worker.shutdown().catch(() => {
+            // Worker shutdown can fail if server is already gone — ignore
+          })
+        )
+      );
 
-    // Stop server process (NodeServerManager already has its own 5s SIGKILL fallback)
-    if (this.serverManager.isRunning()) {
-      await this.serverManager.stop();
+      const timeoutMs = 10_000;
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      await Promise.race([
+        workerShutdown,
+        new Promise<void>((resolve) => {
+          timeoutHandle = setTimeout(resolve, timeoutMs);
+        }),
+      ]);
+      clearTimeout(timeoutHandle);
+      this.workers.clear();
+
+      // Stop server process (NodeServerManager already has its own 5s SIGKILL fallback)
+      if (this.serverManager.isRunning()) {
+        await this.serverManager.stop();
+      }
+
+      this.host = undefined;
+
+      // Emit server state changed event
+      this.emit("serverStateChanged");
+    } finally {
+      this.stopping = false;
     }
-
-    this.host = undefined;
-
-    // Emit server state changed event
-    this.emit("serverStateChanged");
   }
 
   /**
@@ -273,44 +305,79 @@ export class PlutoManager {
     }
 
     // Check if we already have a worker for this notebook
-    let worker = this.workers.get(notebookPath);
-
-    if (!worker && this.host) {
-      // Get notebook content - use provided content or read from file
-      let notebookContent: string;
-      try {
-        if (documentContent) {
-          notebookContent = documentContent;
-        } else {
-          notebookContent = await this.fileReader.readFile(notebookPath);
-        }
-
-        worker = await this.host.createWorker(notebookContent.trim());
+    const worker = this.workers.get(notebookPath);
+    if (worker) {
+      if (!worker.connected) {
         await worker.connect();
-
-        // Tell Pluto which file this notebook lives at so it can track saves.
-        // Only works when the server shares the same filesystem (localhost).
-        // We must delete the file first — moveTo throws if the path already exists.
-        if (this.isLocalServer()) {
-          await unlink(notebookPath);
-          await worker.moveTo(notebookPath);
-        }
-
-        this.workers.set(notebookPath, worker);
-
-        // Emit notebook opened event
-        this.emit("notebookOpened", notebookPath);
-      } catch (error) {
-        throw new Error(
-          `Cannot create worker: failed to read notebook file: ${error}`
-        );
       }
+      return worker;
     }
 
-    // Ensure worker is connected
-    if (worker && !worker.connected) {
-      await worker.connect();
+    if (!this.host) {
+      return undefined;
     }
+
+    // Share one in-flight creation per path so concurrent callers
+    // don't create duplicate workers for the same notebook
+    let pending = this.pendingWorkers.get(notebookPath);
+    if (!pending) {
+      pending = this.createWorkerForPath(notebookPath, documentContent);
+      this.pendingWorkers.set(notebookPath, pending);
+      void pending
+        .catch(() => {
+          // Rejection is delivered to getWorker callers awaiting `pending`
+        })
+        .finally(() => {
+          this.pendingWorkers.delete(notebookPath);
+        });
+    }
+    return pending;
+  }
+
+  private async createWorkerForPath(
+    notebookPath: string,
+    documentContent?: string
+  ): Promise<Worker> {
+    if (!this.host) {
+      throw new Error("Cannot create worker: not connected to Pluto server");
+    }
+
+    // Get notebook content - use provided content or read from file
+    let notebookContent: string;
+    try {
+      notebookContent =
+        documentContent ?? (await this.fileReader.readFile(notebookPath));
+    } catch (error) {
+      throw new Error(
+        `Cannot create worker: failed to read notebook file: ${error}`
+      );
+    }
+
+    const worker = await this.host.createWorker(notebookContent.trim());
+    try {
+      await worker.connect();
+
+      // Tell Pluto which file this notebook lives at so it can track saves.
+      // Only works when the server shares the same filesystem (localhost).
+      // We must delete the file first — moveTo throws if the path already exists.
+      if (this.isLocalServer()) {
+        await unlink(notebookPath);
+        await worker.moveTo(notebookPath);
+      }
+    } catch (error) {
+      // Don't leak the worker if connect/move failed
+      void worker.shutdown().catch(() => {});
+      throw new Error(
+        `Cannot create worker for ${notebookPath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+
+    this.workers.set(notebookPath, worker);
+
+    // Emit notebook opened event
+    this.emit("notebookOpened", notebookPath);
 
     return worker;
   }
@@ -490,8 +557,13 @@ export class PlutoManager {
     // Execute code at index 0 (creates a temporary cell)
     const result = await worker.waitSnippet(0, code);
 
-    // Delete the cell immediately after execution
-    await worker.deleteSnippets([result.cell_id]);
+    // Delete the cell immediately after execution. Best-effort: the result
+    // matters more than the cleanup, so a failed delete is not fatal.
+    try {
+      await worker.deleteSnippets([result.cell_id]);
+    } catch {
+      // Ephemeral cell stays behind — will be cleaned up with the worker
+    }
 
     return result;
   }

--- a/src/plutoManager.ts
+++ b/src/plutoManager.ts
@@ -338,7 +338,8 @@ export class PlutoManager {
     notebookPath: string,
     documentContent?: string
   ): Promise<Worker> {
-    if (!this.host) {
+    const host = this.host;
+    if (!host) {
       throw new Error("Cannot create worker: not connected to Pluto server");
     }
 
@@ -353,7 +354,7 @@ export class PlutoManager {
       );
     }
 
-    const worker = await this.host.createWorker(notebookContent.trim());
+    const worker = await host.createWorker(notebookContent.trim());
     try {
       await worker.connect();
 
@@ -363,6 +364,13 @@ export class PlutoManager {
       if (this.isLocalServer()) {
         await unlink(notebookPath);
         await worker.moveTo(notebookPath);
+      }
+
+      // The server may have been stopped (or replaced) while we were
+      // connecting — registering the worker now would leak it into a
+      // manager whose stop() has already run
+      if (this.stopping || this.host !== host) {
+        throw new Error("Pluto server was stopped while opening the notebook");
       }
     } catch (error) {
       // Don't leak the worker if connect/move failed

--- a/src/plutoManager.ts
+++ b/src/plutoManager.ts
@@ -606,8 +606,11 @@ export class PlutoManager {
           // Wait a bit for cleanup
           await new Promise((resolve) => setTimeout(resolve, 100));
 
-          // Recreate worker
-          await this.getWorker(notebook.path);
+          // Recreate worker and let listeners (controller) resubscribe
+          const worker = await this.getWorker(notebook.path);
+          if (worker) {
+            this.emit("workerRecreated", notebook.path, worker);
+          }
 
           void this.logger.showInfoMessage(
             `Reconnected to notebook: ${notebook.path.split("/").pop()}`

--- a/src/plutoServerTask.ts
+++ b/src/plutoServerTask.ts
@@ -74,6 +74,27 @@ export class PlutoServerTaskManager {
           "[PlutoServerTask] Found existing task, reusing it instead of creating new one"
         );
         this.taskExecution = execution;
+
+        // Adopt the reused task's port — it may differ from our configured one
+        const taskPort = execution.task.definition.port as number | undefined;
+        if (taskPort && taskPort !== this.actualPort) {
+          this.actualPort = taskPort;
+          this.onPortChangedCallback?.(taskPort);
+        }
+
+        // Watch the adopted task for termination like a task we started
+        this.taskEndListener ??= vscode.tasks.onDidEndTaskProcess((e) => {
+          if (e.execution === this.taskExecution) {
+            this.taskExecution = undefined;
+            this.serverReadyPromise = undefined;
+            this.serverReadyResolve = undefined;
+            this.isStarting = false;
+            this.actualPort = this.port;
+            this.taskEndListener?.dispose();
+            this.taskEndListener = undefined;
+            this.onStopCallback?.();
+          }
+        });
         return;
       }
     }
@@ -222,7 +243,6 @@ export class PlutoServerTaskManager {
 
     // Poll until the server responds
     try {
-      await new Promise((r) => setTimeout(r, 15000));
       await this.pollServerReady();
       if (this.serverReadyResolve) {
         this.serverReadyResolve();
@@ -245,7 +265,9 @@ export class PlutoServerTaskManager {
    * Poll server URL until it responds
    */
   private async pollServerReady(): Promise<void> {
-    const maxAttempts = 60;
+    // Generous budget: the task process runs Pkg setup before Pluto.run,
+    // which can take minutes on first run
+    const maxAttempts = 300;
     const pollInterval = 1000;
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {

--- a/src/plutoServerTask.ts
+++ b/src/plutoServerTask.ts
@@ -323,6 +323,18 @@ export class PlutoServerTaskManager {
       endListener?.dispose();
     }
 
+    // If the task outlived the bounded wait, stop tracking it now — its
+    // eventual exit must not fire onStopCallback (and a spurious
+    // "stopped unexpectedly" prompt) after this intentional stop returns
+    if (this.taskExecution === execution) {
+      this.taskExecution = undefined;
+      this.serverReadyPromise = undefined;
+      this.serverReadyResolve = undefined;
+      this.isStarting = false;
+      this.taskEndListener?.dispose();
+      this.taskEndListener = undefined;
+    }
+
     this.actualPort = this.port;
   }
 

--- a/src/plutoServerTask.ts
+++ b/src/plutoServerTask.ts
@@ -269,14 +269,38 @@ export class PlutoServerTaskManager {
   }
 
   /**
-   * Stop Pluto server task
+   * Stop Pluto server task. Waits (bounded) for the task process to end so
+   * callers observe a consistent stopped state before continuing.
    */
   public async stop(): Promise<void> {
-    if (!this.taskExecution) {
+    const execution = this.taskExecution;
+    if (!execution) {
       return;
     }
 
-    this.taskExecution.terminate();
+    let endListener: vscode.Disposable | undefined;
+    const ended = new Promise<void>((resolve) => {
+      endListener = vscode.tasks.onDidEndTaskProcess((e) => {
+        if (e.execution === execution) {
+          resolve();
+        }
+      });
+    });
+
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    try {
+      execution.terminate();
+      await Promise.race([
+        ended,
+        new Promise<void>((resolve) => {
+          timeoutHandle = setTimeout(resolve, 5000);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timeoutHandle);
+      endListener?.dispose();
+    }
+
     this.actualPort = this.port;
   }
 

--- a/src/plutoTerminal.ts
+++ b/src/plutoTerminal.ts
@@ -435,16 +435,25 @@ using InteractiveUtils
   /**
    * Wait for worker to become idle
    */
-  private async waitForIdle(worker: Worker): Promise<void> {
-    const maxWaitTime = 2 * 60000; // 60 seconds max
+  private async waitForIdle(
+    worker: Worker,
+    isStale?: () => boolean
+  ): Promise<void> {
+    const maxWaitTime = 2 * 60000;
     const checkInterval = 500; // Check every 500ms
     const startTime = Date.now();
 
     while (!worker.isIdle()) {
+      // The user cancelled (Ctrl+C) — stop waiting and stop writing
+      // progress dots into whatever they're doing now
+      if (isStale?.()) {
+        return;
+      }
+
       // Check if we've exceeded max wait time
       if (Date.now() - startTime > maxWaitTime) {
         throw new Error(
-          "Timeout waiting for notebook to become idle (60 seconds)"
+          "Timeout waiting for notebook to become idle (2 minutes)"
         );
       }
 
@@ -452,12 +461,14 @@ using InteractiveUtils
       await new Promise((resolve) => setTimeout(resolve, checkInterval));
 
       // Show progress indicator every 2 seconds
-      if ((Date.now() - startTime) % 2000 < checkInterval) {
+      if ((Date.now() - startTime) % 2000 < checkInterval && !isStale?.()) {
         this.write("\x1b[33m.\x1b[0m");
       }
     }
 
-    this.write("\r\n");
+    if (!isStale?.()) {
+      this.write("\r\n");
+    }
   }
 
   /**
@@ -507,7 +518,13 @@ using InteractiveUtils
         );
 
         // Wait for notebook to become idle
-        await this.waitForIdle(worker);
+        await this.waitForIdle(
+          worker,
+          () => generation !== this.executionGeneration
+        );
+        if (generation !== this.executionGeneration) {
+          return;
+        }
       }
 
       // Execute code ephemerally using PlutoManager

--- a/src/plutoTerminal.ts
+++ b/src/plutoTerminal.ts
@@ -25,6 +25,9 @@ export class PlutoTerminalProvider implements vscode.Pseudoterminal {
   private inputBuffer = "";
   private cursorPosition = 0; // Position in the input buffer
   private isExecuting = false;
+  // Bumped on Ctrl+C and on each new execution; stale executions compare
+  // against it before touching shared terminal state
+  private executionGeneration = 0;
   private readonly context?: vscode.ExtensionContext;
 
   // Command history
@@ -271,8 +274,11 @@ using InteractiveUtils
       // Ctrl+C - interrupt
       if (this.isExecuting) {
         this.write("\r\n\x1b[31m^C\x1b[0m\r\n");
+        // Invalidate the in-flight execution so its completion doesn't
+        // clobber state or print a stray prompt (the Julia-side
+        // computation itself is not cancelled — interrupt is a TODO)
+        this.executionGeneration++;
         this.isExecuting = false;
-        // TODO: Add interrupt support
         this.writePrompt();
       } else {
         this.inputBuffer = "";
@@ -469,8 +475,11 @@ using InteractiveUtils
         return await this.handleSpecialCommand(code);
       }
 
+      // Example commands resolve to Julia code that runs like normal input
       code = this.handleExampleCommand(code);
-      return;
+      if (!code) {
+        return;
+      }
     }
 
     if (!this.notebookPath) {
@@ -481,6 +490,7 @@ using InteractiveUtils
     }
 
     this.isExecuting = true;
+    const generation = ++this.executionGeneration;
 
     try {
       // Get worker from PlutoManager (it handles creation/caching)
@@ -503,19 +513,27 @@ using InteractiveUtils
       // Execute code ephemerally using PlutoManager
       const result = await this.plutoManager.executeCodeEphemeral(worker, code);
 
-      // Render output
-      await this.renderOutput(result);
+      // Render output — unless the user cancelled with Ctrl+C meanwhile
+      if (generation === this.executionGeneration) {
+        await this.renderOutput(result);
+      }
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      this.write(`\x1b[31mError: ${errorMessage}\x1b[0m\r\n`);
       this.outputChannel.appendLine(
         `Terminal execution error: ${errorMessage}`
       );
+      if (generation === this.executionGeneration) {
+        this.write(`\x1b[31mError: ${errorMessage}\x1b[0m\r\n`);
+      }
     } finally {
-      this.isExecuting = false;
-      this.write("\r\n");
-      this.writePrompt();
+      // A Ctrl+C (or a newer execution) already reclaimed the terminal —
+      // a stale completion must not reset state or print another prompt
+      if (generation === this.executionGeneration) {
+        this.isExecuting = false;
+        this.write("\r\n");
+        this.writePrompt();
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Concurrency-hardening pass across the shared PlutoManager core, the `@plutojl/cli` command-line tool, the MCP HTTP server, and the VSCode extension. Produced by an iterative review/fix loop, finished with an adversarial multi-agent review of the branch diff (9 confirmed findings, all fixed here).

### PlutoManager (shared core)
- `start()` and per-notebook `getWorker()` are single-flight: concurrent MCP tool calls / cell executions no longer double-start the server or create duplicate workers (which also double-`unlink`ed the notebook file)
- Worker creation that loses a race with `stop()` shuts the worker down instead of leaking it into a stopped manager; failed connect/moveTo no longer leaks workers or misreports as a file-read error
- Intentional `stop()` no longer triggers the "Pluto server stopped unexpectedly — Restart?" prompt or duplicate `serverStateChanged` events; open notebooks are remembered and recreated on the next `start()`
- `restartNotebook` emits `workerRecreated` so the controller resubscribes (tree-view reconnect previously left every later execution hanging on a dead worker's events)

### CLI (`npx @plutojl/cli`)
- Julia/juliaup/Pkg setup runs via async spawn instead of `spawnSync` — the tool server and its `/health` endpoint stay responsive during the up-to-10-minute first-run setup (previously the whole event loop froze)
- Ctrl+C shuts down both the tool server and Pluto (SIGINT/SIGTERM owned by `run` with a reentrancy guard; the old SIGINT handler stopped only the MCP server)
- Missing Julia reports an error and keeps the tool server alive instead of `process.exit(1)`
- `tools`/`call` resolve the MCP port from `PLUTO_MCP_PORT`/`.plutomcp.json` like `run` does
- `call --timeout <seconds>` (default 120s, was a hard 30s) with an honest timeout message
- `install` writes `"type": "sse"` — matching the transport the server actually speaks
- `start_pluto_server`/`connect_to_pluto_server` drop their ignored `port` parameter and report the real server URL; `get_notebook_status` reports `server_url` and open-notebook count
- Child pipes are drained so chatty processes can't deadlock on a full pipe buffer

### VSCode extension
- Activation survives an MCP port conflict (two windows) instead of dying before the serializer registers; Pluto autostart is non-blocking and re-registers open notebooks once the server is up
- One bad patch (e.g. for an ephemeral/MCP-created cell with no editor counterpart) no longer aborts the whole patch batch and leaves real cells spinning; unknown cells are skipped
- Execution end status honors `errored`; interrupt is per-notebook, applies after `interrupt()` lands, and releases spinners even on failure; worker recreation / server loss end orphaned executions
- Reused `pluto-server` tasks adopt their actual port and are watched for termination; `stop()` waits (bounded) and detaches so a slow-dying task can't fire a late spurious crash prompt
- Terminal: Ctrl+C uses a generation counter so cancelled executions can't interleave output/prompts with the next command; example commands (`.plot` …) actually execute
- Closed notebooks unsubscribe and end their executions (workers stay alive for MCP clients); controller `dispose()` cleans up its own listeners and no longer disposes the shared manager

## Tests

- New `src/__tests__/plutoManagerConcurrency.test.ts` — 8 mock-based tests covering single-flight start/getWorker, failed-start retry, intentional-stop suppression, and worker cleanup on failed connect (no Julia required)
- Full suite: 59/59 locally (with Pluto installed); CLI smoke-tested live: `run --no-pluto` → `/health` → `tools` → `call` → SIGINT clean shutdown

## Notes

- Follow-up idea (not in this PR): migrate the MCP endpoint to streamable HTTP alongside legacy SSE, then `install` can write `"type": "http"` again
- `npm test` (vscode-test) hangs in headless WSL on `--install-extension`; CI runs `test:unit` only (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
