### PR TITLE
fix: address open issues — TOML metadata, custom URLs, port clashes, hangs, notebook adoption

### DIFF
--- a/packages/advanced-pluto-mcp/README.md
+++ b/packages/advanced-pluto-mcp/README.md
@@ -116,6 +116,8 @@ These tools are callable from the command line via `call`, and exposed to AI ass
 | `open_notebook`           | Open a notebook file                       |
 | `move_notebook`           | Move a notebook to a new path              |
 | `save_notebook`           | Save the running notebook to disk          |
+| `export_notebook_html`    | Export a static HTML snapshot to disk      |
+| `wait_for_notebook_idle`  | Block until no cell is running or queued   |
 | `list_notebooks`          | List all open notebooks                    |
 | `get_notebook_url`        | Get the Pluto web UI URL for a notebook    |
 | `list_cells`              | List cells with IDs and execution status   |

--- a/src/__tests__/depotPath.test.ts
+++ b/src/__tests__/depotPath.test.ts
@@ -1,0 +1,45 @@
+import { resolveJuliaDepotPath, isWindows } from "../platformUtils.js";
+import * as os from "os";
+import * as path from "path";
+
+describe("resolveJuliaDepotPath", () => {
+  const originalDepot = process.env.JULIA_DEPOT_PATH;
+  const separator = isWindows() ? ";" : ":";
+
+  afterEach(() => {
+    if (originalDepot === undefined) {
+      delete process.env.JULIA_DEPOT_PATH;
+    } else {
+      process.env.JULIA_DEPOT_PATH = originalDepot;
+    }
+  });
+
+  it("defaults to the home depot when unset", () => {
+    delete process.env.JULIA_DEPOT_PATH;
+    expect(resolveJuliaDepotPath()).toBe(path.join(os.homedir(), ".julia"));
+  });
+
+  it("expands a leading ~ to the home directory (issue #34)", () => {
+    process.env.JULIA_DEPOT_PATH = "~/.julia";
+    expect(resolveJuliaDepotPath()).toBe(path.join(os.homedir(), ".julia"));
+  });
+
+  it("respects an existing absolute depot path", () => {
+    const custom = path.join(os.homedir(), "custom-depot");
+    process.env.JULIA_DEPOT_PATH = custom;
+    expect(resolveJuliaDepotPath()).toBe(custom);
+  });
+
+  it("preserves multi-entry depot paths, expanding each ~", () => {
+    const custom = path.join(os.homedir(), "custom-depot");
+    process.env.JULIA_DEPOT_PATH = ["~/depot-a", custom].join(separator);
+    expect(resolveJuliaDepotPath()).toBe(
+      [path.join(os.homedir(), "depot-a"), custom].join(separator)
+    );
+  });
+
+  it("falls back to the home depot for relative entries", () => {
+    process.env.JULIA_DEPOT_PATH = "relative/depot";
+    expect(resolveJuliaDepotPath()).toBe(path.join(os.homedir(), ".julia"));
+  });
+});

--- a/src/__tests__/plutoManagerConcurrency.test.ts
+++ b/src/__tests__/plutoManagerConcurrency.test.ts
@@ -66,6 +66,17 @@ function createFakeWorker(overrides: Partial<Worker> = {}): Worker {
 }
 
 describe("PlutoManager concurrency", () => {
+  // connect() probes the server URL; no real server exists in these tests
+  const realFetch = global.fetch;
+  beforeAll(() => {
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+    })) as unknown as typeof fetch;
+  });
+  afterAll(() => {
+    global.fetch = realFetch;
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });

--- a/src/__tests__/plutoSerializer.test.ts
+++ b/src/__tests__/plutoSerializer.test.ts
@@ -283,6 +283,99 @@ describe("Pluto Serializer Functions", () => {
     });
   });
 
+  describe("cell metadata round-trip (issue #28)", () => {
+    it("does not write pluto_cell_id or default metadata as TOML annotations", () => {
+      const cellId = uuidv4();
+      const cell: NotebookCellData = {
+        kind: NotebookCellKind.Code,
+        value: "x = 1",
+        languageId: "julia",
+        metadata: { pluto_cell_id: cellId },
+      };
+
+      const serialized = serializePlutoNotebook([cell], uuidv4(), "0.20.21");
+
+      expect(serialized).not.toContain("pluto_cell_id =");
+      expect(serialized).not.toContain("show_logs");
+      expect(serialized).not.toContain("skip_as_script");
+      // The cell id must still appear as the cell marker
+      expect(serialized).toContain(`# ╔═╡ ${cellId}`);
+    });
+
+    it("preserves real Pluto metadata like disabled", () => {
+      const cell: NotebookCellData = {
+        kind: NotebookCellKind.Code,
+        value: "x = 1",
+        languageId: "julia",
+        metadata: { pluto_cell_id: uuidv4(), disabled: true },
+      };
+
+      const serialized = serializePlutoNotebook([cell], uuidv4(), "0.20.21");
+      expect(serialized).toContain("disabled = true");
+      expect(serialized).not.toContain("pluto_cell_id =");
+    });
+
+    it("round-trips code_folded through cell metadata", () => {
+      const cellId = uuidv4();
+      const notebook = `### A Pluto.jl notebook ###
+# v0.20.21
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ ${cellId}
+x = 1
+
+# ╔═╡ Cell order:
+# ╟─${cellId}
+`;
+
+      const parsed = parsePlutoNotebook(notebook);
+      expect(parsed.cells[0].metadata?.code_folded).toBe(true);
+
+      const serialized = serializePlutoNotebook(
+        parsed.cells,
+        parsed.notebook_id,
+        parsed.pluto_version
+      );
+      // Folded cells appear with the folded marker in the cell order
+      expect(serialized).toContain(`# ╟─${cellId}`);
+      expect(serialized).not.toContain("code_folded =");
+    });
+
+    it("self-heals files poisoned with embedded pluto_cell_id metadata", () => {
+      const markerId = uuidv4();
+      const staleId = uuidv4();
+      const notebook = `### A Pluto.jl notebook ###
+# v0.20.21
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ ${markerId}
+# ╠═╡ show_logs = false
+# ╠═╡ pluto_cell_id = "${staleId}"
+b = 1
+
+# ╔═╡ Cell order:
+# ╠═${markerId}
+`;
+
+      const parsed = parsePlutoNotebook(notebook);
+      // The marker-derived id wins over the stale embedded one
+      expect(parsed.cells[0].metadata?.pluto_cell_id).toBe(markerId);
+
+      const serialized = serializePlutoNotebook(
+        parsed.cells,
+        parsed.notebook_id,
+        parsed.pluto_version
+      );
+      expect(serialized).not.toContain("pluto_cell_id =");
+      // Non-default show_logs=false from the file is preserved
+      expect(serialized).toContain("show_logs = false");
+    });
+  });
+
   describe("Error handling", () => {
     it("should handle empty content", async () => {
       expect(() => parsePlutoNotebook("")).toThrow();

--- a/src/cli/nodeServerManager.ts
+++ b/src/cli/nodeServerManager.ts
@@ -4,7 +4,11 @@ import * as path from "path";
 import * as fs from "fs";
 import type { IPlutoServerManager } from "../plutoManagerTypes.ts";
 import { isPortAvailable, findAvailablePort } from "../portUtils.ts";
-import { getExecutableName, isWindows } from "../platformUtils.ts";
+import {
+  getExecutableName,
+  isWindows,
+  resolveJuliaDepotPath,
+} from "../platformUtils.ts";
 
 /**
  * Run a child process to completion without blocking the event loop
@@ -130,7 +134,7 @@ export class NodeServerManager implements IPlutoServerManager {
       // 5. Environment variables
       const env: Record<string, string> = {
         ...(process.env as Record<string, string>),
-        JULIA_DEPOT_PATH: path.join(os.homedir(), ".julia"),
+        JULIA_DEPOT_PATH: resolveJuliaDepotPath(),
         JULIA_LOAD_PATH: isWindows() ? ";" : ":",
       };
       if (this.workDir) {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -25,7 +25,19 @@ export async function run(config: CliConfig): Promise<void> {
 
   // Start the MCP HTTP server first (so health endpoint is available during Pluto startup)
   const mcpServer = new PlutoMCPHttpServer(plutoManager, config.mcpPort);
-  await mcpServer.start();
+  try {
+    await mcpServer.start();
+  } catch (err) {
+    console.error(
+      `[cli] Could not start the tool server on port ${config.mcpPort}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    console.error(
+      `[cli] Is another 'run' already active? Pass --mcp-port <port> to use a different port.`
+    );
+    process.exit(1);
+  }
 
   console.log(
     `[cli] MCP server listening at http://localhost:${config.mcpPort}/mcp`

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -14,6 +14,36 @@ import PlutoGuide from "./PLUTO_GUIDE.md";
 let mcpServerInstance: PlutoMCPHttpServer | undefined;
 
 /**
+ * Default bound on how long a tool call may block on cell execution.
+ * Long computations keep running server-side; the call returns guidance
+ * to poll instead of hanging the MCP client forever (see issue #38).
+ */
+const EXECUTION_TIMEOUT_MS = 5 * 60_000;
+
+type TimeoutResult<T> = { timedOut: false; value: T } | { timedOut: true };
+
+async function withExecutionTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs = EXECUTION_TIMEOUT_MS
+): Promise<TimeoutResult<T>> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<TimeoutResult<T>>((resolve) => {
+    timeoutHandle = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
+  });
+  try {
+    return await Promise.race([
+      promise.then((value): TimeoutResult<T> => ({ timedOut: false, value })),
+      timeout,
+    ]);
+  } finally {
+    clearTimeout(timeoutHandle);
+    // The original promise keeps running after a timeout — don't let its
+    // eventual rejection become an unhandled rejection
+    void promise.catch(() => {});
+  }
+}
+
+/**
  * HTTP/SSE-based MCP Server for Pluto Notebooks
  * This allows the extension and MCP clients to share the same PlutoManager instance
  */
@@ -274,12 +304,30 @@ export class PlutoMCPHttpServer {
           throw new Error(`Cell ${cell_id} not found`);
         }
 
-        const result = await this.plutoManager.executeCell(
-          worker,
-          cell_id,
-          cellData.input.code
+        const outcome = await withExecutionTimeout(
+          this.plutoManager.executeCell(worker, cell_id, cellData.input.code)
         );
 
+        if (outcome.timedOut) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  {
+                    cell_id: cell_id,
+                    timed_out: true,
+                    message: `Cell is still running after ${EXECUTION_TIMEOUT_MS / 1000}s. It continues to execute — use wait_for_notebook_idle or poll read_cell to get the result.`,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        const result = outcome.value;
         return {
           content: [
             {
@@ -320,8 +368,29 @@ export class PlutoMCPHttpServer {
           throw new Error(`Notebook ${path} is not open`);
         }
 
-        const result = await worker.waitSnippet(index, code);
+        const outcome = await withExecutionTimeout(
+          worker.waitSnippet(index, code)
+        );
 
+        if (outcome.timedOut) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  {
+                    timed_out: true,
+                    message: `Execution is still running after ${EXECUTION_TIMEOUT_MS / 1000}s. The cell WAS created (at index ${index}) and continues to run — use list_cells to find its id, then wait_for_notebook_idle or read_cell to get the result. Do NOT retry create_cell.`,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        const result = outcome.value;
         return {
           content: [
             {
@@ -542,11 +611,29 @@ export class PlutoMCPHttpServer {
           throw new Error(`Notebook ${path} is not open`);
         }
 
-        const result = await this.plutoManager.executeCodeEphemeral(
-          worker,
-          code
+        const outcome = await withExecutionTimeout(
+          this.plutoManager.executeCodeEphemeral(worker, code)
         );
 
+        if (outcome.timedOut) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  {
+                    timed_out: true,
+                    message: `Code is still running after ${EXECUTION_TIMEOUT_MS / 1000}s. It keeps executing in a temporary cell that is deleted automatically when it finishes — use wait_for_notebook_idle to wait for it. For long computations prefer create_cell so the result stays inspectable.`,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        const result = outcome.value;
         return {
           content: [
             {
@@ -915,6 +1002,64 @@ export class PlutoMCPHttpServer {
       }
     );
 
+    // Wait for notebook idle
+    server.tool(
+      "wait_for_notebook_idle",
+      "Block until the notebook has no running or queued cells (or the timeout passes). Use this once after a create_cell/execute_cell/execute_code timeout or after edit_cell kicks off a reactive cascade — instead of polling list_cells/read_cell in a loop.",
+      {
+        path: z.string().describe("Path to the notebook"),
+        timeout_seconds: z
+          .number()
+          .describe("Maximum seconds to wait (default 120, max 600)")
+          .optional()
+          .default(120),
+      },
+      async ({ path, timeout_seconds }) => {
+        if (!this.plutoManager.isConnected()) {
+          throw new Error("Pluto server is not running");
+        }
+
+        const worker = await this.plutoManager.getWorker(path);
+
+        if (!worker) {
+          throw new Error(`Notebook ${path} is not open`);
+        }
+
+        const waitedFrom = Date.now();
+        const deadline =
+          waitedFrom + Math.min(Math.max(timeout_seconds, 1), 600) * 1000;
+        while (!worker.isIdle() && Date.now() < deadline) {
+          await new Promise((resolve) => setTimeout(resolve, 500));
+        }
+
+        const busyCells = worker
+          .getSnippets()
+          .filter((s) => s.result.running || s.result.queued)
+          .map((s) => s.cell_id);
+        const idle = busyCells.length === 0;
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  idle,
+                  waited_seconds: Math.round((Date.now() - waitedFrom) / 1000),
+                  still_busy_cells: busyCells,
+                  message: idle
+                    ? "Notebook is idle — results are ready to read."
+                    : "Timed out with cells still running — call wait_for_notebook_idle again or read partial state with list_cells.",
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+    );
+
     // Get Notebook URL
     server.tool(
       "get_notebook_url",
@@ -959,10 +1104,20 @@ export class PlutoMCPHttpServer {
         const sessionId = transport.sessionId;
         this.transports.set(sessionId, transport);
 
+        // Keep idle SSE connections alive through proxies/OS sleep — a
+        // silently dropped stream loses the response of any in-flight
+        // long tool call (issue #38)
+        const keepalive = setInterval(() => {
+          if (!res.writableEnded) {
+            res.write(": keepalive\n\n");
+          }
+        }, 30_000);
+
         transport.onclose = () => {
           console.log(
             `[MCP HTTP] SSE transport closed for session ${sessionId}`
           );
+          clearInterval(keepalive);
           this.transports.delete(sessionId);
         };
 

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -853,6 +853,56 @@ export class PlutoMCPHttpServer {
       }
     );
 
+    // Export Notebook HTML
+    server.tool(
+      "export_notebook_html",
+      "Export the notebook's current state as a self-contained static HTML file (like Pluto's 'Export to HTML' button) and write it to disk.",
+      {
+        path: z.string().describe("Path of the open notebook"),
+        output_path: z
+          .string()
+          .describe(
+            "File path for the HTML export (defaults to the notebook path with a .html extension)"
+          )
+          .optional(),
+      },
+      async ({ path, output_path }) => {
+        if (!this.plutoManager.isConnected()) {
+          throw new Error("Pluto server is not running");
+        }
+
+        const worker = await this.plutoManager.getWorker(path);
+
+        if (!worker) {
+          throw new Error(`Notebook ${path} is not open`);
+        }
+
+        const exportUrl = `${this.plutoManager.getServerUrl()}/notebookexport?id=${worker.notebook_id}`;
+        const response = await fetch(exportUrl, {
+          signal: AbortSignal.timeout(60_000),
+        });
+        if (!response.ok) {
+          throw new Error(
+            `Export failed: ${response.status} ${response.statusText}`
+          );
+        }
+        const html = await response.text();
+
+        const savePath =
+          output_path ?? path.replace(/(\.pluto)?\.jl$/, "") + ".html";
+        await writeFile(savePath, html, "utf-8");
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Notebook exported to ${savePath} (${html.length} bytes)`,
+            },
+          ],
+        };
+      }
+    );
+
     // Delete Cell
     server.tool(
       "delete_cell",

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -369,7 +369,7 @@ export class PlutoMCPHttpServer {
         }
 
         const outcome = await withExecutionTimeout(
-          worker.waitSnippet(index, code)
+          this.plutoManager.runSnippet(worker, index, code)
         );
 
         if (outcome.timedOut) {

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -5,6 +5,7 @@ import { writeFile } from "fs/promises";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import type { PlutoManager } from "./plutoManager.ts";
+import { isPortAvailable, findAvailablePort } from "./portUtils.ts";
 import { z } from "zod";
 // @ts-expect-error - esbuild will load this as text
 import PlutoGuide from "./PLUTO_GUIDE.md";
@@ -21,11 +22,18 @@ export class PlutoMCPHttpServer {
   private httpServer?: HttpServer;
   private readonly transports: Map<string, SSEServerTransport> = new Map();
   private readonly plutoManager: PlutoManager;
-  private readonly port: number;
+  private port: number;
+  private readonly dynamicPort: boolean;
 
-  constructor(plutoManager: PlutoManager, port = 3100) {
+  /**
+   * @param dynamicPort - when the configured port is busy, move to the next
+   * free one instead of failing (used by the extension so multiple VSCode
+   * windows can coexist; the CLI stays strict so `tools`/`call` can find it)
+   */
+  constructor(plutoManager: PlutoManager, port = 3100, dynamicPort = false) {
     this.plutoManager = plutoManager;
     this.port = port;
+    this.dynamicPort = dynamicPort;
     this.app = express();
     this.app.use(express.json());
     this.setupRoutes();
@@ -1014,6 +1022,14 @@ export class PlutoMCPHttpServer {
   }
 
   public async start(): Promise<void> {
+    if (this.dynamicPort && !(await isPortAvailable(this.port))) {
+      const fallbackPort = await findAvailablePort(this.port + 1);
+      console.log(
+        `[MCP HTTP] Port ${this.port} is in use (another window?), using ${fallbackPort} instead`
+      );
+      this.port = fallbackPort;
+    }
+
     return await new Promise((resolve, reject) => {
       this.httpServer = this.app.listen(this.port, (error?: Error) => {
         if (error) {
@@ -1095,7 +1111,8 @@ export function initializeMCPServer(
     return;
   }
 
-  mcpServerInstance = new PlutoMCPHttpServer(plutoManager, port);
+  // Dynamic port: a second VSCode window must not fail on a busy port
+  mcpServerInstance = new PlutoMCPHttpServer(plutoManager, port, true);
   outputChannel.appendLine(`MCP server initialized on port ${port}`);
 }
 

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -2,11 +2,41 @@
  * Platform detection and platform-specific utilities
  */
 
+import * as os from "os";
+import * as path from "path";
+
 /**
  * Check if running on Windows
  */
 export function isWindows(): boolean {
   return process.platform === "win32";
+}
+
+/**
+ * Resolve the JULIA_DEPOT_PATH to pass to spawned Julia processes.
+ * Julia requires absolute depot entries — a literal "~" is treated as a
+ * relative directory named "~" (issue #34). Respects an existing
+ * absolute setting, expands "~"-prefixed entries, and falls back to
+ * the default depot in the user's home directory.
+ */
+export function resolveJuliaDepotPath(): string {
+  const separator = isWindows() ? ";" : ":";
+  const existing = process.env.JULIA_DEPOT_PATH;
+
+  if (existing?.trim()) {
+    const expanded = existing
+      .split(separator)
+      .map((entry) =>
+        entry.startsWith("~") ? path.join(os.homedir(), entry.slice(1)) : entry
+      )
+      .join(separator);
+    const first = expanded.split(separator)[0];
+    if (first && path.isAbsolute(first)) {
+      return expanded;
+    }
+  }
+
+  return path.join(os.homedir(), ".julia");
 }
 
 /**

--- a/src/plutoManager.ts
+++ b/src/plutoManager.ts
@@ -3,6 +3,7 @@ import { Host, serialize } from "@plutojl/rainbow";
 import type { IPlutoServerManager, IFileReader } from "./plutoManagerTypes.ts";
 import { EventEmitter } from "events";
 import { unlink } from "fs/promises";
+import { resolve as resolvePath } from "path";
 
 /**
  * Events emitted by PlutoManager
@@ -36,6 +37,7 @@ export class PlutoManager {
   private host?: Host; // Host from @plutojl/rainbow
   private readonly workers: Map<string, Worker> = new Map(); // notebook_id -> Worker
   private readonly pendingWorkers: Map<string, Promise<Worker>> = new Map(); // in-flight worker creation, keyed by path
+  private readonly adoptedWorkers: Set<string> = new Set(); // paths of notebooks we attached to but don't own (e.g. open in the user's browser)
   private startPromise?: Promise<void>; // in-flight start(), shared by concurrent callers
   private stopping = false; // suppresses "stopped unexpectedly" handling during intentional stop
   private serverUrl: string;
@@ -117,8 +119,8 @@ export class PlutoManager {
     }
 
     // Close all workers
-    for (const worker of this.workers.values()) {
-      void worker.shutdown();
+    for (const [notebookPath, worker] of this.workers.entries()) {
+      void this.releaseWorker(notebookPath, worker).catch(() => {});
     }
     this.workers.clear();
 
@@ -265,8 +267,8 @@ export class PlutoManager {
 
       // Close all workers with a timeout — don't let a hung worker block shutdown
       const workerShutdown = Promise.allSettled(
-        [...this.workers.values()].map((worker) =>
-          worker.shutdown().catch(() => {
+        [...this.workers.entries()].map(([notebookPath, worker]) =>
+          this.releaseWorker(notebookPath, worker).catch(() => {
             // Worker shutdown can fail if server is already gone — ignore
           })
         )
@@ -349,6 +351,50 @@ export class PlutoManager {
     return pending;
   }
 
+  /**
+   * Release a worker: shut down the notebook if we own it, otherwise just
+   * close our connection — adopted notebooks (open in the user's browser)
+   * must keep running.
+   */
+  private async releaseWorker(
+    notebookPath: string,
+    worker: Worker
+  ): Promise<void> {
+    if (this.adoptedWorkers.has(notebookPath)) {
+      this.adoptedWorkers.delete(notebookPath);
+      try {
+        worker.close();
+      } catch {
+        // Connection may already be gone
+      }
+      return;
+    }
+    await worker.shutdown();
+  }
+
+  /**
+   * Find a notebook already running on the server for this file path.
+   * Returns its notebook_id, or undefined when none matches or the
+   * listing fails.
+   */
+  private async findRunningNotebook(
+    host: Host,
+    notebookPath: string
+  ): Promise<string | undefined> {
+    try {
+      const running = (await host.workers()) as unknown as Array<{
+        notebook_id?: string;
+        path?: string;
+      }>;
+      const target = resolvePath(notebookPath);
+      return running.find(
+        (nb) => nb.notebook_id && nb.path && resolvePath(nb.path) === target
+      )?.notebook_id;
+    } catch {
+      return undefined;
+    }
+  }
+
   private async createWorkerForPath(
     notebookPath: string,
     documentContent?: string
@@ -356,6 +402,32 @@ export class PlutoManager {
     const host = this.host;
     if (!host) {
       throw new Error("Cannot create worker: not connected to Pluto server");
+    }
+
+    // If the server already manages this file (e.g. the user's own browser
+    // tab has it open), adopt that notebook — uploading a copy and calling
+    // moveTo would fail with "File exists already" (issue #40)
+    if (this.isLocalServer()) {
+      const runningId = await this.findRunningNotebook(host, notebookPath);
+      if (runningId) {
+        const worker = host.worker(runningId);
+        try {
+          await worker.connect();
+          if (this.stopping || this.host !== host) {
+            throw new Error(
+              "Pluto server was stopped while opening the notebook"
+            );
+          }
+        } catch (error) {
+          // Do NOT shut the notebook down — we don't own it (it may be
+          // open in the user's browser)
+          throw new Error(this.describeServerError(error));
+        }
+        this.workers.set(notebookPath, worker);
+        this.adoptedWorkers.add(notebookPath);
+        this.emit("notebookOpened", notebookPath);
+        return worker;
+      }
     }
 
     // Get notebook content - use provided content or read from file
@@ -572,7 +644,7 @@ export class PlutoManager {
 
       // Emit notebook closed event
       this.emit("notebookClosed", notebookPath);
-      void worker.shutdown();
+      void this.releaseWorker(notebookPath, worker).catch(() => {});
     }
   }
 
@@ -627,8 +699,8 @@ export class PlutoManager {
    * Close all notebook connections
    */
   public async dispose(): Promise<void> {
-    for (const worker of this.workers.values()) {
-      await worker.shutdown();
+    for (const [notebookPath, worker] of this.workers.entries()) {
+      await this.releaseWorker(notebookPath, worker).catch(() => {});
     }
     this.workers.clear();
 

--- a/src/plutoManager.ts
+++ b/src/plutoManager.ts
@@ -148,9 +148,13 @@ export class PlutoManager {
   }
 
   /**
-   * Check if Pluto server is running
+   * Check if a Pluto server is available for work. With a custom server
+   * URL there is no owned process — being connected is what counts.
    */
   public isRunning(): boolean {
+    if (this.usingCustomServerUrl) {
+      return this.isConnected();
+    }
     return this.serverManager.isRunning() && this.isConnected();
   }
 
@@ -162,11 +166,22 @@ export class PlutoManager {
   }
 
   /**
-   * Connect to an existing Pluto server without starting a new one
+   * Connect to an existing Pluto server without starting a new one.
+   * Fails fast with a clear error when the server is unreachable.
    */
   public async connect(): Promise<void> {
     if (this.isConnected()) {
       return;
+    }
+
+    try {
+      await fetch(this.serverUrl, { signal: AbortSignal.timeout(5000) });
+    } catch (error) {
+      throw new Error(
+        `Cannot reach Pluto server at ${this.serverUrl}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     }
 
     this.host = new Host(this.serverUrl);
@@ -354,7 +369,12 @@ export class PlutoManager {
       );
     }
 
-    const worker = await host.createWorker(notebookContent.trim());
+    let worker: Worker;
+    try {
+      worker = await host.createWorker(notebookContent.trim());
+    } catch (error) {
+      throw new Error(this.describeServerError(error));
+    }
     try {
       await worker.connect();
 
@@ -489,6 +509,22 @@ export class PlutoManager {
    */
   public async moveNotebook(worker: Worker, newPath: string): Promise<void> {
     await worker.moveTo(newPath);
+  }
+
+  /**
+   * Turn opaque HTTP failures from the Pluto server into actionable errors.
+   */
+  private describeServerError(error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("403")) {
+      return (
+        `${message} — the Pluto server at ${this.serverUrl} refused the request (authentication). ` +
+        `Start it with secrets disabled, e.g. ` +
+        `Pluto.run(port=1234; require_secret_for_access=false, require_secret_for_open_links=false, launch_browser=false) ` +
+        `— only on a machine that is not exposed to the internet.`
+      );
+    }
+    return message;
   }
 
   /**

--- a/src/plutoManager.ts
+++ b/src/plutoManager.ts
@@ -4,6 +4,7 @@ import type { IPlutoServerManager, IFileReader } from "./plutoManagerTypes.ts";
 import { EventEmitter } from "events";
 import { unlink } from "fs/promises";
 import { resolve as resolvePath } from "path";
+import { v4 as uuidv4 } from "uuid";
 
 /**
  * Events emitted by PlutoManager
@@ -413,6 +414,17 @@ export class PlutoManager {
         const worker = host.worker(runningId);
         try {
           await worker.connect();
+
+          // A notebook opened but never granted execution (Pluto's safe
+          // preview, "waiting_for_permission") silently ignores run
+          // requests — grant permission like createWorker's init does.
+          // A notebook with a live session is left untouched.
+          if (
+            worker.notebook_state?.process_status === "waiting_for_permission"
+          ) {
+            await worker.restart();
+          }
+
           if (this.stopping || this.host !== host) {
             throw new Error(
               "Pluto server was stopped while opening the notebook"
@@ -663,15 +675,60 @@ export class PlutoManager {
   }
 
   /**
+   * Create a cell, run it, and resolve with its result — robust against
+   * rainbow's waitSnippet missing the terminal update of fast cells (its
+   * listener registers after addSnippet's round trip, by which time a
+   * trivial cell may already be done; with no further update traffic the
+   * promise then never settles). A state poll acts as the fallback.
+   */
+  public async runSnippet(
+    worker: Worker,
+    index: number,
+    code: string
+  ): Promise<CellResultData> {
+    const limitMs = 60 * 60_000;
+    const cellId = uuidv4();
+
+    const viaEvents: Promise<CellResultData> = worker
+      .waitSnippet(index, code, {}, cellId, limitMs)
+      // On timeout waitSnippet rejects with null — let the poll decide
+      .catch(() => new Promise<never>(() => {}));
+
+    let stopPolling = false;
+    const viaPolling = (async (): Promise<CellResultData> => {
+      const deadline = Date.now() + limitMs;
+      while (!stopPolling && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 250));
+        const result = worker.getSnippet(cellId)?.result;
+        if (
+          result &&
+          !result.running &&
+          !result.queued &&
+          (result.output?.last_run_timestamp ?? 0) > 0
+        ) {
+          return result;
+        }
+      }
+      throw new Error("Timed out waiting for cell execution to finish");
+    })();
+
+    try {
+      return await Promise.race([viaEvents, viaPolling]);
+    } finally {
+      stopPolling = true;
+    }
+  }
+
+  /**
    * Execute Julia code in a notebook without creating a persistent cell
-   * This uses waitSnippet at index 0 and then immediately deletes the cell
+   * This uses runSnippet at index 0 and then immediately deletes the cell
    */
   public async executeCodeEphemeral(
     worker: Worker,
     code: string
   ): Promise<CellResultData> {
     // Execute code at index 0 (creates a temporary cell)
-    const result = await worker.waitSnippet(0, code);
+    const result = await this.runSnippet(worker, 0, code);
 
     // Delete the cell immediately after execution. Best-effort: the result
     // matters more than the cleanup, so a failed delete is not fatal.

--- a/src/plutoSerializer.ts
+++ b/src/plutoSerializer.ts
@@ -151,16 +151,18 @@ export function serializePlutoNotebook(
     // get serialized as `# ╠═╡` TOML annotations that Pluto's parser
     // rejects (see issue #28). pluto_cell_id is already encoded by the
     // cell marker; code_folded is a top-level field, not metadata.
-    const {
-      pluto_cell_id: _plutoCellId,
-      code_folded: codeFolded,
-      ...plutoMetadata
-    } = (cell.metadata ?? {}) as Record<string, unknown>;
+    const plutoMetadata = { ...(cell.metadata ?? {}) } as Record<
+      string,
+      unknown
+    >;
+    delete plutoMetadata.pluto_cell_id;
+    const codeFolded = plutoMetadata.code_folded === true;
+    delete plutoMetadata.code_folded;
 
     cellInputs[cellId] = {
       cell_id: cellId,
       code: code,
-      code_folded: codeFolded === true,
+      code_folded: codeFolded,
       metadata: {
         // Pluto defaults — only non-default values get written to the file
         disabled: false,

--- a/src/plutoSerializer.ts
+++ b/src/plutoSerializer.ts
@@ -85,9 +85,13 @@ export function createVsCodeCellFromPlutoCell(
     upstream_cells_map: {},
   };
   cellData.outputs = [formatCellOutput(results)];
+  // pluto_cell_id and code_folded come after the spread so values from the
+  // cell marker/input always win over stale keys inside file metadata
+  // (files written by older versions embedded pluto_cell_id as metadata)
   cellData.metadata = {
-    pluto_cell_id: plutoCellId,
     ...cellInput.metadata,
+    pluto_cell_id: plutoCellId,
+    code_folded: cellInput.code_folded ?? false,
   };
   return cellData;
 }
@@ -143,15 +147,26 @@ export function serializePlutoNotebook(
       code = `#VSCODE-MARKDOWN\nmd"""${cell.value}"""`;
     }
 
+    // VSCode-internal keys must not leak into Pluto cell metadata — they
+    // get serialized as `# ╠═╡` TOML annotations that Pluto's parser
+    // rejects (see issue #28). pluto_cell_id is already encoded by the
+    // cell marker; code_folded is a top-level field, not metadata.
+    const {
+      pluto_cell_id: _plutoCellId,
+      code_folded: codeFolded,
+      ...plutoMetadata
+    } = (cell.metadata ?? {}) as Record<string, unknown>;
+
     cellInputs[cellId] = {
       cell_id: cellId,
       code: code,
-      code_folded: false,
+      code_folded: codeFolded === true,
       metadata: {
+        // Pluto defaults — only non-default values get written to the file
         disabled: false,
-        show_logs: false,
+        show_logs: true,
         skip_as_script: false,
-        ...cell.metadata,
+        ...plutoMetadata,
       },
     };
 

--- a/src/plutoServerTask.ts
+++ b/src/plutoServerTask.ts
@@ -1,9 +1,7 @@
 import * as vscode from "vscode";
-import * as os from "os";
-import * as path from "path";
 import { isDefined } from "./helpers.ts";
 import { isPortAvailable, findAvailablePort } from "./portUtils.ts";
-import { isWindows } from "./platformUtils.ts";
+import { isWindows, resolveJuliaDepotPath } from "./platformUtils.ts";
 import {
   getJuliaExecutable,
   getPackageServer,
@@ -162,7 +160,7 @@ export class PlutoServerTaskManager {
     // --- Step 4: Build env vars for the server process ---
     const env: { [key: string]: string } = {
       JULIA_PLUTO_VSCODE_WORKSPACE: workspacePath,
-      JULIA_DEPOT_PATH: path.join(os.homedir(), ".julia"),
+      JULIA_DEPOT_PATH: resolveJuliaDepotPath(),
       JULIA_LOAD_PATH: isWindows() ? ";" : ":",
       JULIAHUB_TOKEN: juliaHubToken,
     };


### PR DESCRIPTION
## Summary

Works through the open issue backlog. Six of seven open issues are addressed (five fully, #38/#39 partially — see notes).

### #28 — TOML parse errors, backup-file spam, hung loads (fixed)
The serializer leaked the VSCode-internal `pluto_cell_id` into Pluto cell metadata and forced `show_logs = false` (Pluto's default is `true`), so every save wrote `# ╠═╡` TOML annotations that Pluto's parser rejects. Both keys are gone; a stale embedded `pluto_cell_id` can no longer override the marker-derived id (poisoned files self-heal on next save), and `code_folded` now survives the round-trip.

### #32 — custom Pluto server URL (fixed)
`isRunning()` was always false for custom URLs (no owned process), so cell add/remove handling was skipped entirely — new cells never got a `pluto_cell_id` and could not execute. Connected custom-URL servers now count as running; `connect()` fails fast with a clear "Cannot reach Pluto server at …" error; 403 responses explain the `require_secret_for_access` setup.

### #34 — non-absolute depot path (fixed)
`JULIA_DEPOT_PATH` handed to spawned Julia is now always absolute: existing absolute settings are respected, `~`-prefixed entries are expanded, otherwise the default home depot is used. (Both the CLI's server manager and the VSCode task use the shared helper.)

### #35 — MCP port clash with multiple VSCode windows (fixed)
The extension's MCP server falls back to the next free port instead of failing. The CLI stays strict (`tools`/`call` must find the server at the configured port) but reports the conflict with a `--mcp-port` hint.

### #38 — blocking/hanging MCP calls (mitigated + likely root cause fixed)
- Found a real never-returns bug: rainbow's `waitSnippet` misses the terminal update of fast cells (listener registers after `addSnippet`'s round trip; with no further update traffic the promise never settles). `create_cell`/`execute_code` now go through `PlutoManager.runSnippet`, which backs the event path with a state poll.
- `create_cell` / `execute_cell` / `execute_code` return after 5 minutes with structured "still running — here's how to poll" guidance instead of blocking indefinitely (computation continues server-side).
- New `wait_for_notebook_idle` tool replaces the `read_cell`/`list_cells` polling storms (46% of observed calls in the issue's analysis).
- SSE keepalive comments every 30s so proxies/OS sleep don't silently drop the stream carrying an in-flight response.

### #39 — validation-harness gaps (partial)
- New `export_notebook_html` tool writes Pluto's static HTML export to disk.
- The "MCP up but Pluto still booting" confusion was fixed on this repo's main already (async spawn keeps `/health` responsive during setup).
- Not addressed here: preserving the embedded Project/Manifest through `save_notebook` — that's a `@plutojl/rainbow` `serialize()` gap (nbpkg state isn't round-tripped) and needs a rainbow release first.

### #40 — `open_notebook` vs. already-managed path (fixed)
When the local server already manages the requested file (e.g. the user's browser tab), the manager now adopts that notebook instead of uploading a copy and dying in `moveTo` with "File exists already". Adopted notebooks are never shut down by us — only disconnected. Safe-preview notebooks (`waiting_for_permission`) get execution granted, matching `createWorker`'s init.

## Tests

- 68/68 unit tests (new: serializer metadata round-trip ×4, depot path resolution ×5)
- Live end-to-end against a real Pluto 1.0.1 server: `/open` a notebook (simulated browser tab) → `open_notebook` adopts it (same notebook id) → `execute_code` returns `84` → `wait_for_notebook_idle` and `export_notebook_html` verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)
