### PR TITLE
fix(julia): keep Julia's bundled depots when spawning the Pluto server

### DIFF
--- a/src/__tests__/depotPath.test.ts
+++ b/src/__tests__/depotPath.test.ts
@@ -14,9 +14,11 @@ describe("resolveJuliaDepotPath", () => {
     }
   });
 
-  it("defaults to the home depot when unset", () => {
+  it("defaults to the home depot plus the bundled system depots when unset", () => {
     delete process.env.JULIA_DEPOT_PATH;
-    expect(resolveJuliaDepotPath()).toBe(path.join(os.homedir(), ".julia"));
+    expect(resolveJuliaDepotPath()).toBe(
+      path.join(os.homedir(), ".julia") + separator
+    );
   });
 
   it("expands a leading ~ to the home directory (issue #34)", () => {
@@ -38,8 +40,10 @@ describe("resolveJuliaDepotPath", () => {
     );
   });
 
-  it("falls back to the home depot for relative entries", () => {
+  it("falls back to the default depots for relative entries", () => {
     process.env.JULIA_DEPOT_PATH = "relative/depot";
-    expect(resolveJuliaDepotPath()).toBe(path.join(os.homedir(), ".julia"));
+    expect(resolveJuliaDepotPath()).toBe(
+      path.join(os.homedir(), ".julia") + separator
+    );
   });
 });

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -17,7 +17,10 @@ export function isWindows(): boolean {
  * Julia requires absolute depot entries — a literal "~" is treated as a
  * relative directory named "~" (issue #34). Respects an existing
  * absolute setting, expands "~"-prefixed entries, and falls back to
- * the default depot in the user's home directory.
+ * the default depot in the user's home directory followed by an empty
+ * entry, which Julia expands to the depots bundled with the Julia
+ * install. Those bundled depots hold artifacts that some distributions
+ * (e.g. Dyad's Julia) load from their system image at startup.
  */
 export function resolveJuliaDepotPath(): string {
   const separator = isWindows() ? ";" : ":";
@@ -36,7 +39,7 @@ export function resolveJuliaDepotPath(): string {
     }
   }
 
-  return path.join(os.homedir(), ".julia");
+  return path.join(os.homedir(), ".julia") + separator;
 }
 
 /**


### PR DESCRIPTION
## Problem

Running **Pluto: Run Server** with the `dyad-3.3.0` juliaup channel crashed immediately:

```
Core.InitError(mod=:OpenBLAS32_jll, error=ErrorException("Artifact \"OpenBLAS32\" was not found by looking in the path \"~/.julia/artifacts/296d14cc…\" …"))
```

Both the extension's server task and `@plutojl/cli` pass `JULIA_DEPOT_PATH=~/.julia`. Julia treats an explicit depot list as complete, so the two depots bundled with the install (`<install>/local/share/julia`, `<install>/share/julia`) are dropped. Stock Julia doesn't notice, but Dyad's Julia 1.12.7 bakes `OpenBLAS32_jll` into its system image and its `__init__` resolves the artifact from `<install>/share/julia/artifacts/` before any user code runs.

## Fix

`resolveJuliaDepotPath()` now returns the default with a trailing empty entry (`~/.julia:` on POSIX, `~/.julia;` on Windows). Julia expands an empty entry to the default system depots, so the bundled depots are back while `Pkg.depots1()` still resolves to `~/.julia` and the `vscode_pluto_notebook` environment lands where it always did. User-supplied `JULIA_DEPOT_PATH` values are passed through unchanged, as before.

Verified on the Dyad 1.12.7 binary and on stock 1.11.7: with the trailing separator both report the full three-entry `DEPOT_PATH`; with the bare `~/.julia` the Dyad binary reproduces the crash.

## Tests

- `src/__tests__/depotPath.test.ts` updated for the new default; the user-supplied-value cases are unchanged.
- `npm run check-types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DktWo8yNPTKr9kd2P6RT2
