### PR TITLE
ci: run the @plutojl/cli release from its package with a self-contained config

### DIFF
--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -62,13 +62,25 @@ jobs:
       - name: Build CLI production bundle
         run: npm run build:production --workspace=packages/advanced-pluto-mcp
 
+      # The extension release may push its version-bump commits to main
+      # while this job runs; semantic-release refuses to publish from a
+      # branch that is behind its remote
+      - name: Sync with the tip of main
+        run: |
+          git fetch origin main
+          git reset --hard origin/main
+
+      # Run from the package directory so its .releaserc.json is the only
+      # config semantic-release loads (the repository's own config would
+      # otherwise be merged in, plugins included)
       - name: Run semantic-release for MCP CLI
+        working-directory: packages/advanced-pluto-mcp
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
-            npx semantic-release --extends ./packages/advanced-pluto-mcp/.releaserc.json --dry-run
+            npx semantic-release --dry-run
           else
-            npx semantic-release --extends ./packages/advanced-pluto-mcp/.releaserc.json
+            npx semantic-release
           fi

--- a/packages/advanced-pluto-mcp/.releaserc.json
+++ b/packages/advanced-pluto-mcp/.releaserc.json
@@ -7,14 +7,13 @@
     [
       "@semantic-release/changelog",
       {
-        "changelogFile": "packages/advanced-pluto-mcp/CHANGELOG.md"
+        "changelogFile": "CHANGELOG.md"
       }
     ],
     [
       "@semantic-release/npm",
       {
-        "npmPublish": false,
-        "pkgRoot": "packages/advanced-pluto-mcp"
+        "npmPublish": false
       }
     ],
     [
@@ -22,7 +21,7 @@
       {
         "assets": [
           {
-            "path": "packages/advanced-pluto-mcp/CHANGELOG.md",
+            "path": "CHANGELOG.md",
             "label": "MCP CLI Changelog"
           }
         ]
@@ -31,10 +30,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": [
-          "packages/advanced-pluto-mcp/package.json",
-          "packages/advanced-pluto-mcp/CHANGELOG.md"
-        ],
+        "assets": ["package.json", "CHANGELOG.md"],
         "message": "chore(mcp-release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]


### PR DESCRIPTION
The automated `@plutojl/cli` release has never succeeded (`mcp-v0.5.5` was a manual baseline tag). Two causes, both fixed here:

1. **Wrong config.** `npx semantic-release --extends ./packages/advanced-pluto-mcp/.releaserc.json` still loads the repository's own `.releaserc.json` and merges the extended file *under* it, so the root plugin list won: `semantic-release-vsce` ran and failed with `ENOPAT No personal access token was detected` because the CLI job does not (and should not) receive `VSCE_PAT`. The CLI config now uses package-relative paths and the job runs with `working-directory: packages/advanced-pluto-mcp`, where that file is the only config semantic-release finds.
2. **Race with the extension release.** Both workflows trigger on the same push; the extension release pushes `chore(release)` and changelog commits to main while the CLI job is already checked out, and semantic-release then declines with "local branch main is behind the remote". The job now resets to `origin/main` right before releasing.

`npmPublish` stays `false`: publishing to npm remains a manual step, as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DktWo8yNPTKr9kd2P6RT2
