### PR TITLE
feat(mcp): read_cell_output tool; cell results summarize outputs instead of inlining them

### DIFF
--- a/.claude/skills/pluto-cli/SKILL.md
+++ b/.claude/skills/pluto-cli/SKILL.md
@@ -51,6 +51,7 @@ npx @plutojl/cli call list_cells '{"path": "/abs/path/nb.pluto.jl"}'
 - Long/slow cells: `edit_cell` with `run: false`, then `execute_cell`, then `wait_for_notebook_idle`.
 - Passing large code through `call`'s JSON argument fights shell escaping — for multi-line cells, write the `.jl` file and `open_notebook`, or pipe carefully quoted JSON.
 - `call --timeout <seconds>` raises the client-side wait (default 120s); `--raw` prints the raw JSON response.
+- Cell results summarize outputs (images come back as a size only). To see a plot: `call read_cell_output '{"path": ..., "cell_id": ..., "as": "image"}'` saves a PNG (`--out <file>` to name it) that you can Read; `"as": "file"` writes the original output next to the notebook; `"as": "text"` returns full markup or long text.
 
 ## Finishing
 

--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -84,3 +84,17 @@ jobs:
           else
             npx semantic-release
           fi
+
+      - name: Format CHANGELOG after semantic-release
+        if: success() && github.event.inputs.dry_run != 'true'
+        run: |
+          if git diff --name-only HEAD~1 | grep -q "packages/advanced-pluto-mcp/CHANGELOG.md"; then
+            npx prettier --write packages/advanced-pluto-mcp/CHANGELOG.md
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add packages/advanced-pluto-mcp/CHANGELOG.md
+            git commit -m "chore: format MCP CHANGELOG [skip ci]" || echo "No formatting changes needed"
+            git push
+          else
+            echo "MCP CHANGELOG.md was not updated, skipping formatting"
+          fi

--- a/packages/advanced-pluto-mcp/CHANGELOG.md
+++ b/packages/advanced-pluto-mcp/CHANGELOG.md
@@ -1,12 +1,10 @@
 # [0.6.0](https://github.com/JuliaPluto/advanced-vscode-extension/compare/mcp-v0.5.5...mcp-v0.6.0) (2026-09-04)
 
-
 ### Bug Fixes
 
-* **julia:** keep Julia's bundled depots when spawning the Pluto server ([#45](https://github.com/JuliaPluto/advanced-vscode-extension/issues/45)) ([9544a7e](https://github.com/JuliaPluto/advanced-vscode-extension/commit/9544a7eb2b2f8284c1328da49bee2db874ad7395))
-
+- **julia:** keep Julia's bundled depots when spawning the Pluto server ([#45](https://github.com/JuliaPluto/advanced-vscode-extension/issues/45)) ([9544a7e](https://github.com/JuliaPluto/advanced-vscode-extension/commit/9544a7eb2b2f8284c1328da49bee2db874ad7395))
 
 ### Features
 
-* **cli:** status discovery, VS Code tool-server detection, strict args, cleaner help ([#46](https://github.com/JuliaPluto/advanced-vscode-extension/issues/46)) ([b114281](https://github.com/JuliaPluto/advanced-vscode-extension/commit/b114281edfe49c274851db5dde36a16a37c1cf94))
-* night-shift roadmap — streamable HTTP, cell sync, terminal interrupt, review fixes ([6fa9b9b](https://github.com/JuliaPluto/advanced-vscode-extension/commit/6fa9b9b2782e0d3b5cc802a3c4181cbbb586e1eb))
+- **cli:** status discovery, VS Code tool-server detection, strict args, cleaner help ([#46](https://github.com/JuliaPluto/advanced-vscode-extension/issues/46)) ([b114281](https://github.com/JuliaPluto/advanced-vscode-extension/commit/b114281edfe49c274851db5dde36a16a37c1cf94))
+- night-shift roadmap — streamable HTTP, cell sync, terminal interrupt, review fixes ([6fa9b9b](https://github.com/JuliaPluto/advanced-vscode-extension/commit/6fa9b9b2782e0d3b5cc802a3c4181cbbb586e1eb))

--- a/packages/advanced-pluto-mcp/README.md
+++ b/packages/advanced-pluto-mcp/README.md
@@ -124,7 +124,7 @@ Example `.plutomcp.json`:
 }
 ```
 
-Cell outputs returned by tools are trimmed for the terminal: byte bodies are decoded (text, SVG) or base64-encoded (images), and bodies longer than 32,000 characters are truncated with a `body_note`; `export_notebook_html` writes the complete output.
+Cell results keep outputs small: text is cut at 4,000 characters, Pluto tree views at 8,000, and images and other binary outputs are replaced by their size with a `body_note`. `read_cell_output` fetches the whole thing — `as: "text"` for markup and long text, `as: "file"` to write it next to the notebook (`<notebook>.assets/<cell_id>.<ext>`), or `as: "image"` to get a picture; SVG plots and other non-raster values are rendered to PNG inside the notebook. From the CLI, image results are saved to a file (`--out`) rather than printed.
 
 Unknown options, options that do not apply to the command, and invalid values are errors (exit code 2). Set `PLUTO_CLI_DEBUG=1` to see stack traces for unexpected failures. Colors follow `NO_COLOR` / `FORCE_COLOR`.
 
@@ -149,7 +149,8 @@ These tools are callable from the command line via `call`, and exposed to AI ass
 | `get_notebook_url`        | Get the Pluto web UI URL for a notebook    |
 | `list_cells`              | List cells with IDs and execution status   |
 | `create_cell`             | Create and execute a new cell              |
-| `read_cell`               | Read cell code and output                  |
+| `read_cell`               | Read cell code and output (summarized)     |
+| `read_cell_output`        | Full output as text, a file, or an image   |
 | `edit_cell`               | Update cell code                           |
 | `execute_cell`            | Run an existing cell                       |
 | `delete_cell`             | Remove a cell                              |

--- a/src/PLUTO_GUIDE.md
+++ b/src/PLUTO_GUIDE.md
@@ -31,6 +31,16 @@ These rules are critical when interacting with Pluto notebooks through the MCP A
 - For slow operations (e.g. `import Pkg; Pkg.add(...)`), prefer: (1) `edit_cell` with `run=false` to set the code, then (2) `execute_cell` to run it, then (3) `wait_for_notebook_idle`.
 - Use `delete_cell` to remove any accidental duplicate cells.
 
+### Reading outputs, plots, and images
+
+Cell results (`create_cell`, `execute_cell`, `read_cell`, `execute_code`) summarize the output: text is cut at 4,000 characters, tree views at 8,000, and images come back as just their mime type and size. When you need the whole output, call `read_cell_output`:
+
+- `{"path": ..., "cell_id": ..., "as": "text"}` — full SVG/HTML markup, long text, or the tree as JSON.
+- `{"path": ..., "cell_id": ..., "as": "file"}` — writes the output to `<notebook>.assets/<cell_id>.<ext>` (or `output_path`) and returns the path. Read that file with your own tools to look at a plot.
+- `{"path": ..., "cell_id": ..., "as": "image"}` — returns the output as an image. SVG plots and any other value with an `image/png` show method are rendered to PNG inside the notebook first, so this works for Plots, Makie, and Images figures. Needs a local Pluto server.
+
+Prefer `as: "image"` to see what a plot looks like, and `as: "file"` when the picture should stay on disk.
+
 ### Pluto Reactivity Rules
 
 - **Each variable can only be defined in one cell.** If you get a "Multiple definitions" error, use `list_cells` to find the duplicate, then `delete_cell` to remove it.

--- a/src/__tests__/mcpOutput.test.ts
+++ b/src/__tests__/mcpOutput.test.ts
@@ -1,38 +1,113 @@
-import { newNotebookSource, presentOutput } from "../notebookOutput.ts";
+import {
+  INLINE_TEXT_LIMIT,
+  INLINE_TREE_LIMIT,
+  extensionFor,
+  fullOutput,
+  newNotebookSource,
+  presentOutput,
+  renderCellToPngCode,
+} from "../notebookOutput.ts";
 
 describe("presentOutput", () => {
-  it("decodes byte bodies of text-like mimes to strings", () => {
-    const svg = "<svg>hi</svg>";
+  it("replaces image bodies with their size and a fetch hint", () => {
     const out = presentOutput({
       mime: "image/svg+xml",
-      body: new TextEncoder().encode(svg),
-    }) as { body: unknown; body_note?: string };
-    expect(out.body).toBe(svg);
+      body: new TextEncoder().encode("<svg>hi</svg>"),
+    }) as { body: unknown; bytes: number; body_note: string };
+    expect(out.body).toBeNull();
+    expect(out.bytes).toBe(13);
+    expect(out.body_note).toMatch(/image\/svg\+xml output of 13 bytes/);
+    expect(out.body_note).toMatch(/read_cell_output/);
+  });
+
+  it("does the same for raster images and PDFs", () => {
+    for (const mime of ["image/png", "application/pdf"]) {
+      const out = presentOutput({ mime, body: new Uint8Array(5) }) as {
+        body: unknown;
+        bytes: number;
+      };
+      expect(out.body).toBeNull();
+      expect(out.bytes).toBe(5);
+    }
+  });
+
+  it("decodes short text bodies and keeps them inline", () => {
+    const out = presentOutput({
+      mime: "text/plain",
+      body: new TextEncoder().encode("42"),
+    }) as { body: string; body_note?: string };
+    expect(out.body).toBe("42");
     expect(out.body_note).toBeUndefined();
   });
 
-  it("base64-encodes binary bodies with a note", () => {
-    const out = presentOutput({
-      mime: "image/png",
-      body: new Uint8Array([137, 80, 78, 71]),
-    }) as { body: string; body_note: string };
-    expect(out.body).toBe(Buffer.from([137, 80, 78, 71]).toString("base64"));
-    expect(out.body_note).toMatch(/image\/png body of 4 bytes/);
-  });
-
-  it("truncates long bodies with a note", () => {
+  it("truncates long text with a note", () => {
     const out = presentOutput({
       mime: "text/html",
-      body: "x".repeat(40_000),
+      body: "x".repeat(INLINE_TEXT_LIMIT + 100),
     }) as { body: string; body_note: string };
-    expect(out.body.length).toBe(32_000);
-    expect(out.body_note).toMatch(/truncated to 32000 of 40000/);
+    expect(out.body.length).toBe(INLINE_TEXT_LIMIT);
+    expect(out.body_note).toMatch(/truncated to 4000 of 4100 characters/);
   });
 
-  it("leaves other outputs alone", () => {
+  it("keeps small tree objects and drops large ones", () => {
+    const small = { mime: "application/vnd.pluto.tree+object", body: { a: 1 } };
+    expect(presentOutput(small)).toEqual(small);
+    const big = presentOutput({
+      mime: "application/vnd.pluto.tree+object",
+      body: { elements: Array.from({ length: 2000 }, (_, i) => [i, "x"]) },
+    }) as { body: unknown; bytes: number; body_note: string };
+    expect(big.body).toBeNull();
+    expect(big.bytes).toBeGreaterThan(INLINE_TREE_LIMIT);
+    expect(big.body_note).toMatch(/not returned inline/);
+  });
+
+  it("leaves non-objects alone", () => {
     expect(presentOutput(undefined)).toBeUndefined();
-    const tree = { mime: "application/vnd.pluto.tree+object", body: { a: 1 } };
-    expect(presentOutput(tree)).toEqual(tree);
+    expect(presentOutput(null)).toBeNull();
+  });
+});
+
+describe("fullOutput", () => {
+  it("decodes text-like byte bodies and keeps binary ones as bytes", () => {
+    const svg = fullOutput({
+      mime: "image/svg+xml",
+      body: new TextEncoder().encode("<svg/>"),
+    });
+    expect(svg?.text).toBe("<svg/>");
+    const png = fullOutput({ mime: "image/png", body: new Uint8Array([1, 2]) });
+    expect(png?.text).toBeUndefined();
+    expect(Array.from(png!.bytes)).toEqual([1, 2]);
+  });
+
+  it("serializes tree objects to JSON text", () => {
+    const tree = fullOutput({
+      mime: "application/vnd.pluto.tree+object",
+      body: { a: 1 },
+    });
+    expect(tree?.text).toBe('{"a":1}');
+  });
+
+  it("returns undefined without a body", () => {
+    expect(fullOutput({ mime: "text/plain" })).toBeUndefined();
+    expect(fullOutput(undefined)).toBeUndefined();
+  });
+});
+
+describe("extensionFor", () => {
+  it("maps common mimes and falls back to bin", () => {
+    expect(extensionFor("image/svg+xml")).toBe("svg");
+    expect(extensionFor("image/png")).toBe("png");
+    expect(extensionFor("text/html")).toBe("html");
+    expect(extensionFor("application/x-unknown")).toBe("bin");
+  });
+});
+
+describe("renderCellToPngCode", () => {
+  it("targets the cell's stored value and escapes the path", () => {
+    const code = renderCellToPngCode("abc-123", 'C:\\tmp\\"x".png');
+    expect(code).toContain('Base.UUID("abc-123")');
+    expect(code).toContain('MIME("image/png")');
+    expect(code).toContain('"C:\\\\tmp\\\\\\"x\\".png"');
   });
 });
 

--- a/src/cli/call.ts
+++ b/src/cli/call.ts
@@ -4,7 +4,10 @@
  * Uses raw fetch + SSE parsing to avoid eventsource polyfill issues in CJS bundles.
  */
 
+import * as fs from "fs";
+import * as path from "path";
 import { VERSION } from "./config.ts";
+import { extensionFor } from "../notebookOutput.ts";
 import { bold, cyan, dim, err, yellow } from "./ui.ts";
 
 interface ToolSchema {
@@ -28,7 +31,12 @@ interface JsonRpcResponse {
   id: number;
   result?: {
     tools?: ToolInfo[];
-    content?: Array<{ type: string; text?: string }>;
+    content?: Array<{
+      type: string;
+      text?: string;
+      data?: string;
+      mimeType?: string;
+    }>;
     isError?: boolean;
   };
   error?: { code: number; message: string };
@@ -278,13 +286,20 @@ export async function listTools(port: number, filter?: string): Promise<void> {
   );
 }
 
+export interface CallOptions {
+  raw: boolean;
+  timeoutMs: number;
+  /** Where to write image content; defaults to ./<cell_id or tool>.<ext>. */
+  out?: string;
+}
+
 export async function callTool(
   port: number,
   toolName: string,
   argsJson: string,
-  raw: boolean,
-  timeoutMs = 120000
+  options: CallOptions
 ): Promise<void> {
+  const { raw, timeoutMs, out } = options;
   let args: unknown;
   try {
     args = JSON.parse(argsJson);
@@ -316,9 +331,26 @@ export async function callTool(
   if (raw) {
     console.log(JSON.stringify(result, null, 2));
   } else {
+    let imageIndex = 0;
     for (const item of result?.content ?? []) {
       if (item.type === "text" && item.text) {
         console.log(item.text);
+      } else if (item.type === "image" && item.data) {
+        // Never print base64 to the terminal: save the image and say where
+        const ext = extensionFor(item.mimeType ?? "image/png");
+        const stem =
+          typeof (args as Record<string, unknown>).cell_id === "string"
+            ? String((args as Record<string, unknown>).cell_id)
+            : toolName;
+        const dest =
+          out ??
+          path.resolve(`${stem}${imageIndex ? `-${imageIndex}` : ""}.${ext}`);
+        fs.mkdirSync(path.dirname(dest), { recursive: true });
+        fs.writeFileSync(dest, Buffer.from(item.data, "base64"));
+        console.log(
+          `${dim("image")} ${item.mimeType ?? ""} written to ${dest}`
+        );
+        imageIndex++;
       }
     }
   }

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -71,6 +71,7 @@ export function helpText(): string {
         `How long to wait for the result ${dim("(default 120)")}`
       ),
       opt("--raw", "Print the raw JSON-RPC result"),
+      opt("--out <file>", "Where to save an image returned by the tool"),
       opt("--mcp-port <port>", "Tool server to talk to"),
     ]),
     "",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -105,13 +105,11 @@ async function main() {
     }
     case "call": {
       const port = await requireMcpPort(resolveMcpPort(args));
-      await callTool(
-        port,
-        args.toolName!,
-        args.toolArgs ?? "{}",
-        args.raw ?? false,
-        (args.timeoutSeconds ?? 120) * 1000
-      );
+      await callTool(port, args.toolName!, args.toolArgs ?? "{}", {
+        raw: args.raw ?? false,
+        timeoutMs: (args.timeoutSeconds ?? 120) * 1000,
+        out: args.out,
+      });
       break;
     }
   }

--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -21,6 +21,7 @@ export interface RawArgs {
   toolName?: string;
   toolArgs?: string;
   raw?: boolean;
+  out?: string;
   timeoutSeconds?: number;
   // status
   json?: boolean;
@@ -126,6 +127,11 @@ const FLAGS: Record<string, FlagSpec> = {
     commands: ["call"],
     value: false,
     apply: (a) => (a.raw = true),
+  },
+  "--out": {
+    commands: ["call"],
+    value: true,
+    apply: (a, v) => (a.out = v),
   },
   "--timeout": {
     commands: ["call", "status"],

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -2,14 +2,23 @@ import express from "express";
 import type { Express, Request, Response } from "express";
 import type { Server as HttpServer } from "http";
 import { existsSync } from "fs";
-import { mkdir, writeFile } from "fs/promises";
-import { dirname } from "path";
+import { mkdir, readFile, rm, writeFile } from "fs/promises";
+import { basename, dirname, extname, join } from "path";
+import { tmpdir } from "os";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { randomUUID } from "crypto";
-import { newNotebookSource, presentOutput } from "./notebookOutput.ts";
+import {
+  extensionFor,
+  fullOutput,
+  isImageMime,
+  isRasterMime,
+  newNotebookSource,
+  presentOutput,
+  renderCellToPngCode,
+} from "./notebookOutput.ts";
 import type { PlutoManager } from "./plutoManager.ts";
 import { isPortAvailable, findAvailablePort } from "./portUtils.ts";
 import { z } from "zod";
@@ -971,6 +980,142 @@ export class PlutoMCPHttpServer {
             {
               type: "text",
               text: `Notebook exported to ${savePath} (${html.length} bytes)`,
+            },
+          ],
+        };
+      }
+    );
+
+    // Read Cell Output
+    server.tool(
+      "read_cell_output",
+      'Fetch a cell\'s complete output, which cell results only summarize. as: "text" returns the full body (SVG/HTML markup, long text, tree JSON); "file" writes it next to the notebook (or to output_path) and returns the path — the way to look at a plot with your own file tools; "image" returns it as an image content block, rendering non-raster values such as SVG plots to PNG inside the notebook first.',
+      {
+        path: z.string().describe("Path to the notebook"),
+        cell_id: z.string().describe("UUID of the cell (from list_cells)"),
+        as: z
+          .enum(["text", "file", "image"])
+          .describe("How to return the output (default text)")
+          .optional()
+          .default("text"),
+        output_path: z
+          .string()
+          .describe(
+            'For as: "file" — where to write; defaults to <notebook>.assets/<cell_id>.<ext>'
+          )
+          .optional(),
+      },
+      async ({ path, cell_id, as, output_path }) => {
+        if (!this.plutoManager.isConnected()) {
+          throw new Error("Pluto server is not running");
+        }
+        const worker = await this.plutoManager.getWorker(path);
+        if (!worker) {
+          throw new Error(`Notebook ${path} is not open`);
+        }
+        const snippet = worker.getSnippet(cell_id);
+        if (!snippet) {
+          throw new Error(`Cell ${cell_id} not found — use list_cells`);
+        }
+        const output = fullOutput(snippet.result.output);
+        if (!output) {
+          throw new Error(`Cell ${cell_id} has no output`);
+        }
+
+        if (as === "text") {
+          const text =
+            output.text ?? Buffer.from(output.bytes).toString("base64");
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  {
+                    cell_id,
+                    mime: output.mime,
+                    bytes: output.bytes.length,
+                    encoding: output.text === undefined ? "base64" : "utf-8",
+                    body: text,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        if (as === "file") {
+          const dest =
+            output_path ??
+            join(
+              dirname(path),
+              `${basename(path, extname(path))}.assets`,
+              `${cell_id}.${extensionFor(output.mime)}`
+            );
+          await mkdir(dirname(dest), { recursive: true });
+          await writeFile(dest, output.bytes);
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Wrote ${output.bytes.length} bytes of ${output.mime} to ${dest}`,
+              },
+            ],
+          };
+        }
+
+        // as === "image"
+        if (isRasterMime(output.mime)) {
+          return {
+            content: [
+              {
+                type: "image",
+                data: Buffer.from(output.bytes).toString("base64"),
+                mimeType: output.mime,
+              },
+              {
+                type: "text",
+                text: `${output.mime}, ${output.bytes.length} bytes`,
+              },
+            ],
+          };
+        }
+        if (!this.plutoManager.isLocalServer()) {
+          throw new Error(
+            `The cell's output is ${output.mime}; rendering it to PNG needs a local Pluto server. Use as: "file" to save the ${isImageMime(output.mime) ? "image" : "output"} instead.`
+          );
+        }
+        const pngPath = join(
+          tmpdir(),
+          `pluto-cell-${cell_id}-${Date.now()}.png`
+        );
+        const render = await this.plutoManager.executeCodeEphemeral(
+          worker,
+          renderCellToPngCode(cell_id, pngPath)
+        );
+        if (render.errored) {
+          const why = fullOutput(render.output)?.text ?? "unknown error";
+          throw new Error(
+            `Could not render cell ${cell_id} as PNG: ${why.slice(0, 500)}. Use as: "file" to save the ${output.mime} output instead.`
+          );
+        }
+        let png: Buffer;
+        try {
+          png = await readFile(pngPath);
+        } finally {
+          await rm(pngPath, { force: true });
+        }
+        return {
+          content: [
+            {
+              type: "image",
+              data: png.toString("base64"),
+              mimeType: "image/png",
+            },
+            {
+              type: "text",
+              text: `Rendered the cell's ${output.mime} output to image/png (${png.length} bytes)`,
             },
           ],
         };

--- a/src/notebookOutput.ts
+++ b/src/notebookOutput.ts
@@ -1,10 +1,18 @@
 import { randomUUID } from "crypto";
 
-/** Longest output body returned inline by a tool; longer bodies are cut with a note. */
-const OUTPUT_BODY_LIMIT = 32_000;
+/** Longest text body returned inline in a cell result. */
+export const INLINE_TEXT_LIMIT = 4_000;
+/** Longest serialized tree (Pluto object view) returned inline in a cell result. */
+export const INLINE_TREE_LIMIT = 8_000;
 
 const TEXT_MIME = /^(text\/|image\/svg|application\/(json|javascript|xml))/;
-const BINARY_MIME = /^(image\/|application\/pdf|application\/octet-stream)/;
+const IMAGE_MIME = /^image\//;
+const RASTER_MIME = /^image\/(png|jpeg|gif|webp)$/;
+/** Mimes whose bodies are never returned inline, only through read_cell_output. */
+const HEAVY_MIME = /^(image\/|application\/pdf|application\/octet-stream)/;
+
+const FETCH_HINT =
+  'use read_cell_output with as: "text", "file", or "image" to fetch it';
 
 function bytesOf(value: unknown): Uint8Array | undefined {
   if (value instanceof Uint8Array) return value;
@@ -12,35 +20,116 @@ function bytesOf(value: unknown): Uint8Array | undefined {
   return undefined;
 }
 
+export function isTextMime(mime: string): boolean {
+  return TEXT_MIME.test(mime);
+}
+
+export function isImageMime(mime: string): boolean {
+  return IMAGE_MIME.test(mime);
+}
+
+export function isRasterMime(mime: string): boolean {
+  return RASTER_MIME.test(mime);
+}
+
+export function extensionFor(mime: string): string {
+  const known: Record<string, string> = {
+    "image/svg+xml": "svg",
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/gif": "gif",
+    "image/webp": "webp",
+    "image/bmp": "bmp",
+    "text/html": "html",
+    "text/plain": "txt",
+    "text/markdown": "md",
+    "application/pdf": "pdf",
+    "application/json": "json",
+    "application/vnd.pluto.tree+object": "json",
+    "application/vnd.pluto.table+object": "json",
+  };
+  return known[mime] ?? "bin";
+}
+
+export interface FullOutput {
+  mime: string;
+  /** Body as bytes, whatever Pluto sent. */
+  bytes: Uint8Array;
+  /** Body as text for text-like mimes and tree objects (serialized JSON). */
+  text: string | undefined;
+}
+
+/** The complete body of a cell output, decoded once, for tools that hand it over whole. */
+export function fullOutput(output: unknown): FullOutput | undefined {
+  if (output === null || typeof output !== "object") return undefined;
+  const record = output as Record<string, unknown>;
+  const mime = typeof record.mime === "string" ? record.mime : "text/plain";
+  const body = record.body;
+  const bytes = bytesOf(body);
+  if (bytes) {
+    return {
+      mime,
+      bytes,
+      text: isTextMime(mime) ? new TextDecoder().decode(bytes) : undefined,
+    };
+  }
+  if (typeof body === "string") {
+    return { mime, bytes: new TextEncoder().encode(body), text: body };
+  }
+  if (body === undefined || body === null) return undefined;
+  const text = JSON.stringify(body);
+  return { mime, bytes: new TextEncoder().encode(text), text };
+}
+
 /**
- * Make a cell output safe and compact for a JSON tool response: byte
- * bodies become text or base64 depending on the mime type, and long
- * bodies are truncated with a note on how to get the whole thing.
+ * Make a cell output compact enough for a tool response. Image and other
+ * heavy bodies are replaced by their size; text is cut at
+ * INLINE_TEXT_LIMIT and tree objects at INLINE_TREE_LIMIT, each with a
+ * note on how to fetch the whole thing.
  */
 export function presentOutput(output: unknown): unknown {
   if (output === null || typeof output !== "object") return output;
   const record = output as Record<string, unknown>;
   const mime = typeof record.mime === "string" ? record.mime : "";
   let body = record.body;
-  let note: string | undefined;
-
   const bytes = bytesOf(body);
+
+  if (HEAVY_MIME.test(mime)) {
+    const size =
+      bytes?.length ?? (typeof body === "string" ? body.length : undefined);
+    return {
+      ...record,
+      body: null,
+      bytes: size,
+      body_note: `${mime} output${size !== undefined ? ` of ${size} bytes` : ""} is not returned inline; ${FETCH_HINT}`,
+    };
+  }
+
   if (bytes) {
-    if (TEXT_MIME.test(mime) || !BINARY_MIME.test(mime)) {
-      body = new TextDecoder().decode(bytes);
-    } else {
-      body = Buffer.from(bytes).toString("base64");
-      note = `${mime} body of ${bytes.length} bytes, base64-encoded`;
-    }
+    body = new TextDecoder().decode(bytes);
   }
 
-  if (typeof body === "string" && body.length > OUTPUT_BODY_LIMIT) {
-    const total = body.length;
-    body = body.slice(0, OUTPUT_BODY_LIMIT);
-    note = `${note ? note + "; " : ""}truncated to ${OUTPUT_BODY_LIMIT} of ${total} characters — use export_notebook_html for the full output`;
+  if (typeof body === "string") {
+    if (body.length <= INLINE_TEXT_LIMIT) return { ...record, body };
+    return {
+      ...record,
+      body: body.slice(0, INLINE_TEXT_LIMIT),
+      body_note: `truncated to ${INLINE_TEXT_LIMIT} of ${body.length} characters; ${FETCH_HINT}`,
+    };
   }
 
-  return note ? { ...record, body, body_note: note } : { ...record, body };
+  if (body !== null && typeof body === "object") {
+    const size = JSON.stringify(body).length;
+    if (size <= INLINE_TREE_LIMIT) return { ...record, body };
+    return {
+      ...record,
+      body: null,
+      bytes: size,
+      body_note: `${mime || "structured"} output of ${size} characters is not returned inline; ${FETCH_HINT}`,
+    };
+  }
+
+  return { ...record, body };
 }
 
 /** Minimal Pluto notebook file, with one markdown title cell when a title is given. */
@@ -68,5 +157,25 @@ export function newNotebookSource(title?: string): string {
     "# ╔═╡ Cell order:",
     `# ╟─${id}`,
     "",
+  ].join("\n");
+}
+
+/**
+ * Julia code that renders the current value of a cell to a PNG file
+ * through its `image/png` show method. Runs inside the notebook, where
+ * PlutoRunner keeps every cell's last value.
+ */
+export function renderCellToPngCode(cellId: string, pngPath: string): string {
+  const escapedPath = pngPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return [
+    "let",
+    `    results = Main.PlutoRunner.cell_results`,
+    `    id = Base.UUID("${cellId}")`,
+    `    haskey(results, id) || error("cell ${cellId} has no value to render")`,
+    `    v = results[id]`,
+    `    showable(MIME("image/png"), v) || error("the cell's value (" * string(typeof(v)) * ") cannot be rendered as image/png")`,
+    `    open(io -> show(io, MIME("image/png"), v), "${escapedPath}", "w")`,
+    `    filesize("${escapedPath}")`,
+    "end",
   ].join("\n");
 }


### PR DESCRIPTION
Follow-up to #46, from the usability trials: even after decoding, an SVG plot in a cell result was 20–100 KB of markup that no agent can use, and tree views of arrays were similarly noisy.

## Cell results are summaries now
`create_cell`, `execute_cell`, `read_cell`, and `execute_code` keep outputs small:
- text bodies are cut at 4,000 characters,
- Pluto tree views (`application/vnd.pluto.tree+object`) at 8,000 characters of JSON,
- image, PDF, and binary bodies are replaced by `{ body: null, bytes: N, body_note: "… use read_cell_output …" }`.

## `read_cell_output(path, cell_id, as)`
| `as` | Returns |
|---|---|
| `"text"` (default) | the full body: SVG/HTML markup, long text, tree JSON; base64 for binary |
| `"file"` | writes to `<notebook>.assets/<cell_id>.<ext>` (or `output_path`) and returns the path |
| `"image"` | an MCP **image** content block. Raster outputs pass through; anything else is rendered to PNG *inside the notebook* via its `image/png` show method, reading the cell's live value from `PlutoRunner.cell_results`. Works for Plots (SVG by default), Makie, and Images. Needs a local Pluto server; the error says to use `"file"` otherwise. |

## CLI
`call` never prints base64. Image content is saved to `./<cell_id>.<ext>` (or `--out <file>`) and the path is printed, so an agent can Read the PNG with its own tools.

## Docs
`PLUTO_GUIDE.md` (served by `learn_pluto_basics`) gets a "Reading outputs, plots, and images" section; CLI README and skill file updated.

## Verification
- New unit tests for the presentation rules, `fullOutput`, `extensionFor`, and the Julia render snippet; `tsc` and `eslint` clean for extension and CLI.
- End to end against a live Pluto under the memory guard: a `plot(1:10, (1:10).^2)` cell returned a 22 KB summary; `as: "text"` gave the SVG; `as: "file"` wrote `plots.pluto.assets/<id>.svg`; `as: "image"` produced a 600×400 PNG of the plot, saved by the CLI; the ephemeral render cell was cleaned up (3 cells remained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DktWo8yNPTKr9kd2P6RT2
