### PR TITLE
fix(mcp): read_cell_output honours the requested file extension; stop Julia first on shutdown

### DIFF
--- a/packages/advanced-pluto-mcp/README.md
+++ b/packages/advanced-pluto-mcp/README.md
@@ -124,7 +124,7 @@ Example `.plutomcp.json`:
 }
 ```
 
-Cell results keep outputs small: text is cut at 4,000 characters, Pluto tree views at 8,000, and images and other binary outputs are replaced by their size with a `body_note`. `read_cell_output` fetches the whole thing — `as: "text"` for markup and long text, `as: "file"` to write it next to the notebook (`<notebook>.assets/<cell_id>.<ext>`), or `as: "image"` to get a picture; SVG plots and other non-raster values are rendered to PNG inside the notebook. From the CLI, image results are saved to a file (`--out`) rather than printed.
+Cell results keep outputs small: text is cut at 4,000 characters, Pluto tree views at 8,000, and images and other binary outputs are replaced by their size with a `body_note`. `read_cell_output` fetches the whole thing — `as: "text"` for markup and long text, `as: "file"` to write it next to the notebook (`<notebook>.assets/<cell_id>.<ext>`; an `output_path` ending in `.png` renders SVG plots to PNG), or `as: "image"` to get a picture; SVG plots and other non-raster values are rendered to PNG inside the notebook. From the CLI, image results are saved to a file (`--out`) rather than printed.
 
 Unknown options, options that do not apply to the command, and invalid values are errors (exit code 2). Set `PLUTO_CLI_DEBUG=1` to see stack traces for unexpected failures. Colors follow `NO_COLOR` / `FORCE_COLOR`.
 

--- a/src/PLUTO_GUIDE.md
+++ b/src/PLUTO_GUIDE.md
@@ -36,7 +36,7 @@ These rules are critical when interacting with Pluto notebooks through the MCP A
 Cell results (`create_cell`, `execute_cell`, `read_cell`, `execute_code`) summarize the output: text is cut at 4,000 characters, tree views at 8,000, and images come back as just their mime type and size. When you need the whole output, call `read_cell_output`:
 
 - `{"path": ..., "cell_id": ..., "as": "text"}` — full SVG/HTML markup, long text, or the tree as JSON.
-- `{"path": ..., "cell_id": ..., "as": "file"}` — writes the output to `<notebook>.assets/<cell_id>.<ext>` (or `output_path`) and returns the path. Read that file with your own tools to look at a plot.
+- `{"path": ..., "cell_id": ..., "as": "file"}` — writes the output to `<notebook>.assets/<cell_id>.<ext>` (or `output_path`) and returns the path. Naming `output_path` with `.png` renders a non-raster output (such as an SVG plot) to PNG; any other extension that does not match the output's type is refused.
 - `{"path": ..., "cell_id": ..., "as": "image"}` — returns the output as an image. SVG plots and any other value with an `image/png` show method are rendered to PNG inside the notebook first, so this works for Plots, Makie, and Images figures. Needs a local Pluto server.
 
 Prefer `as: "image"` to see what a plot looks like, and `as: "file"` when the picture should stay on disk.

--- a/src/__tests__/mcpOutput.test.ts
+++ b/src/__tests__/mcpOutput.test.ts
@@ -17,7 +17,7 @@ describe("presentOutput", () => {
     expect(out.body).toBeNull();
     expect(out.bytes).toBe(13);
     expect(out.body_note).toMatch(/image\/svg\+xml output of 13 bytes/);
-    expect(out.body_note).toMatch(/read_cell_output/);
+    expect(out.body_note).toMatch(/as: "image" to see it/);
   });
 
   it("does the same for raster images and PDFs", () => {

--- a/src/cli/nodeServerManager.ts
+++ b/src/cli/nodeServerManager.ts
@@ -184,6 +184,13 @@ export class NodeServerManager implements IPlutoServerManager {
         stdio: ["ignore", "pipe", "pipe"],
         env,
       });
+      // Whatever ends this process, Julia must not outlive it
+      const julia = this.juliaProcess;
+      process.once("exit", () => {
+        if (!julia.killed && julia.exitCode === null) {
+          julia.kill("SIGKILL");
+        }
+      });
 
       this.juliaProcess.stdout?.on("data", (data: Buffer) => {
         process.stderr.write(`[julia] ${data}`);

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -184,13 +184,14 @@ export async function run(config: CliConfig): Promise<void> {
       console.error("[cli] Shutdown is taking too long; exiting.");
       process.exit(1);
     }, 15_000).unref();
+    // Julia first: it is the process a user would otherwise find orphaned
     try {
-      await mcpServer.stop();
+      await plutoManager.stop();
     } catch {
       // ignore
     }
     try {
-      await plutoManager.stop();
+      await mcpServer.stop();
     } catch {
       // ignore
     }

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -13,7 +13,6 @@ import { randomUUID } from "crypto";
 import {
   extensionFor,
   fullOutput,
-  isImageMime,
   isRasterMime,
   newNotebookSource,
   presentOutput,
@@ -1045,21 +1044,63 @@ export class PlutoMCPHttpServer {
           };
         }
 
+        const renderPng = async (): Promise<Buffer> => {
+          if (!this.plutoManager.isLocalServer()) {
+            throw new Error(
+              `The cell's output is ${output.mime}; rendering it to PNG needs a local Pluto server. Use as: "file" with a .${extensionFor(output.mime)} name to save the original output instead.`
+            );
+          }
+          const pngPath = join(
+            tmpdir(),
+            `pluto-cell-${cell_id}-${Date.now()}.png`
+          );
+          const render = await this.plutoManager.executeCodeEphemeral(
+            worker,
+            renderCellToPngCode(cell_id, pngPath)
+          );
+          if (render.errored) {
+            const why = fullOutput(render.output)?.text ?? "unknown error";
+            throw new Error(
+              `Could not render cell ${cell_id} as PNG: ${why.slice(0, 500)}. Use as: "file" with a .${extensionFor(output.mime)} name to save the ${output.mime} output instead.`
+            );
+          }
+          try {
+            return await readFile(pngPath);
+          } finally {
+            await rm(pngPath, { force: true });
+          }
+        };
+
         if (as === "file") {
+          const nativeExt = extensionFor(output.mime);
           const dest =
             output_path ??
             join(
               dirname(path),
               `${basename(path, extname(path))}.assets`,
-              `${cell_id}.${extensionFor(output.mime)}`
+              `${cell_id}.${nativeExt}`
             );
+          const wantedExt = extname(dest).slice(1).toLowerCase();
+          let bytes: Uint8Array = output.bytes;
+          let mime = output.mime;
+          if (wantedExt && wantedExt !== nativeExt) {
+            // The caller named a format: render to it when possible, refuse otherwise
+            if (wantedExt === "png" && !isRasterMime(output.mime)) {
+              bytes = await renderPng();
+              mime = "image/png";
+            } else if (!(wantedExt === "jpg" && nativeExt === "jpg")) {
+              throw new Error(
+                `The cell's output is ${output.mime}, which is written as .${nativeExt}; name the file that way, or use .png to have it rendered${isRasterMime(output.mime) ? "" : " inside the notebook"}.`
+              );
+            }
+          }
           await mkdir(dirname(dest), { recursive: true });
-          await writeFile(dest, output.bytes);
+          await writeFile(dest, bytes);
           return {
             content: [
               {
                 type: "text",
-                text: `Wrote ${output.bytes.length} bytes of ${output.mime} to ${dest}`,
+                text: `Wrote ${bytes.length} bytes of ${mime} to ${dest}`,
               },
             ],
           };
@@ -1081,31 +1122,7 @@ export class PlutoMCPHttpServer {
             ],
           };
         }
-        if (!this.plutoManager.isLocalServer()) {
-          throw new Error(
-            `The cell's output is ${output.mime}; rendering it to PNG needs a local Pluto server. Use as: "file" to save the ${isImageMime(output.mime) ? "image" : "output"} instead.`
-          );
-        }
-        const pngPath = join(
-          tmpdir(),
-          `pluto-cell-${cell_id}-${Date.now()}.png`
-        );
-        const render = await this.plutoManager.executeCodeEphemeral(
-          worker,
-          renderCellToPngCode(cell_id, pngPath)
-        );
-        if (render.errored) {
-          const why = fullOutput(render.output)?.text ?? "unknown error";
-          throw new Error(
-            `Could not render cell ${cell_id} as PNG: ${why.slice(0, 500)}. Use as: "file" to save the ${output.mime} output instead.`
-          );
-        }
-        let png: Buffer;
-        try {
-          png = await readFile(pngPath);
-        } finally {
-          await rm(pngPath, { force: true });
-        }
+        const png = await renderPng();
         return {
           content: [
             {

--- a/src/notebookOutput.ts
+++ b/src/notebookOutput.ts
@@ -13,6 +13,8 @@ const HEAVY_MIME = /^(image\/|application\/pdf|application\/octet-stream)/;
 
 const FETCH_HINT =
   'use read_cell_output with as: "text", "file", or "image" to fetch it';
+const IMAGE_HINT =
+  'use read_cell_output with as: "image" to see it, or as: "file" / "text" for the original output';
 
 function bytesOf(value: unknown): Uint8Array | undefined {
   if (value instanceof Uint8Array) return value;
@@ -101,7 +103,7 @@ export function presentOutput(output: unknown): unknown {
       ...record,
       body: null,
       bytes: size,
-      body_note: `${mime} output${size !== undefined ? ` of ${size} bytes` : ""} is not returned inline; ${FETCH_HINT}`,
+      body_note: `${mime} output${size !== undefined ? ` of ${size} bytes` : ""} is not returned inline; ${IMAGE_MIME.test(mime) ? IMAGE_HINT : FETCH_HINT}`,
     };
   }
 


### PR DESCRIPTION
Two Sonnet agents were asked to build a plot and describe it from the rendered image without being told `read_cell_output` exists. Both found the tool from the cell-result note and both correctly described their plots from PNGs (verified against the files). Both also fell into the same hole first: `as: "file"` with `output_path: ".../chart.png"` wrote SVG bytes under a `.png` name.

## Changes
- **File mode honours the extension.** `output_path` ending in `.png` renders a non-raster output (SVG plots) to PNG inside the notebook, the same path `as: "image"` uses. Any other extension that does not match the output's type is refused with the right one named. Default naming is unchanged (`<notebook>.assets/<cell_id>.<native ext>`).
- **Image outputs' `body_note` leads with `as: "image"`**, since that is what someone who wants to *see* a plot needs; `file`/`text` are mentioned after.
- **Shutdown:** `run` stops Pluto before the tool server and SIGKILLs the Julia child on process exit, so a SIGTERM to the CLI never leaves Julia listening (one trial observed an orphan with the previous ordering).

## Verified live
Against a Plots `bar([1,3,2])` cell: `output_path: bars.png` → `PNG image data, 600 x 400`; `output_path: bars.txt` → refused with "written as .svg; name the file that way, or use .png…"; default → `nb.pluto.assets/<id>.svg`. SIGTERM to the node process: both ports free and no Julia left after ~12 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DktWo8yNPTKr9kd2P6RT2
