### PR TITLE
ci: sync the extension release job with the tip of main before releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,14 @@ jobs:
           echo "filename=$VSIX_FILE" >> $GITHUB_OUTPUT
           echo "Built VSIX file: $VSIX_FILE"
 
+      # The MCP CLI release may push its version-bump commits to main while
+      # this job runs; semantic-release refuses to publish from a branch
+      # that is behind its remote
+      - name: Sync with the tip of main
+        run: |
+          git fetch origin main
+          git reset --hard origin/main
+
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The extension release for #49 skipped with `local branch main is behind the remote` because the MCP CLI release pushed its changelog commits first, the mirror image of the race fixed for the CLI job in #47. This adds the same reset-to-`origin/main` step before semantic-release in `release.yml`. Merging this triggers the extension release, which will pick up the pending `fix:` commit from #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DktWo8yNPTKr9kd2P6RT2