### PR TITLE
feat(cli): argument files and relative-path resolution; cell edits and runs now go through Pluto

### DIFF
--- a/.claude/skills/pluto-cli/SKILL.md
+++ b/.claude/skills/pluto-cli/SKILL.md
@@ -49,7 +49,8 @@ npx @plutojl/cli call list_cells '{"path": "/abs/path/nb.pluto.jl"}'
 - Notebooks are **not auto-saved**: call `save_notebook` to persist. Never edit the `.pluto.jl` on disk while it's open — Pluto owns the file.
 - Prefer plain `using PackageName` — Pluto installs packages automatically.
 - Long/slow cells: `edit_cell` with `run: false`, then `execute_cell`, then `wait_for_notebook_idle`.
-- Passing large code through `call`'s JSON argument fights shell escaping — for multi-line cells, write the `.jl` file and `open_notebook`, or pipe carefully quoted JSON.
+- Passing large code through `call`'s JSON argument fights shell escaping — write the arguments to a file and pass `@args.json`, or pipe JSON on stdin with `-`.
+- Notebook inside a Julia project that needs the local package? One environment cell: `Pkg.activate(mktempdir()); Pkg.develop(path=joinpath(@__DIR__, ".."))`, then the `using` lines in the same cell. Never `Pkg.add` into the user's project. `@__DIR__` is the notebook's directory; `pwd()` is not. Details: `call learn_pluto_basics`.
 - `call --timeout <seconds>` raises the client-side wait (default 120s); `--raw` prints the raw JSON response.
 - Cell results summarize outputs (images come back as a size only). To see a plot: `call read_cell_output '{"path": ..., "cell_id": ..., "as": "image"}'` saves a PNG (`--out <file>` to name it) that you can Read; `"as": "file"` writes the original output next to the notebook; `"as": "text"` returns full markup or long text.
 

--- a/packages/advanced-pluto-mcp/README.md
+++ b/packages/advanced-pluto-mcp/README.md
@@ -69,12 +69,13 @@ npx @plutojl/cli tools [name] [--mcp-port <port>]
 
 ### `call`
 
-Call a notebook tool from the command line. The tool name and JSON arguments may appear before or after the options.
+Call a notebook tool from the command line. The tool name and JSON arguments may appear before or after the options. The JSON may also come from a file (`@args.json`) or stdin (`-`), which avoids shell quoting for multi-line cell code. Relative `path`, `output_path`, and `new_path` arguments are resolved against the current directory before they are sent, since the server needs absolute notebook paths.
 
 ```bash
-npx @plutojl/cli call <tool_name> [json_args] [options]
+npx @plutojl/cli call <tool_name> [json_args | @file | -] [options]
 
 # Examples
+npx @plutojl/cli call learn_pluto_basics          # read this first
 npx @plutojl/cli call get_notebook_status
 npx @plutojl/cli call open_notebook '{"path": "/tmp/nb.pluto.jl"}'
 npx @plutojl/cli call execute_code '{"code": "sqrt(2)"}'

--- a/src/PLUTO_GUIDE.md
+++ b/src/PLUTO_GUIDE.md
@@ -23,6 +23,38 @@ These rules are critical when interacting with Pluto notebooks through the MCP A
 - To persist changes to disk, call `save_notebook` explicitly. **Notebooks are NOT auto-saved.**
 - **If a change (folding, reordering, etc.) does not appear to have persisted on disk, do not attempt to fix it yourself.** Just inform the user — Pluto manages file writes and the issue may be on the server side.
 
+### Notebooks inside a Julia project (local packages, environments, paths)
+
+By default a Pluto notebook has its **own** package environment, managed by Pluto: `using Foo` installs `Foo` automatically. That environment knows nothing about the project the notebook file happens to live in, so `using MyLocalPackage` fails with `Package MyLocalPackage not found in current path`.
+
+To use a local (unregistered or `dev`) package, put **one** environment cell in the notebook that activates an environment containing it, and do all `using` statements for that environment **in the same cell**. Prefer a temporary environment so the user's `Project.toml` is never modified:
+
+```julia
+begin
+    import Pkg
+    Pkg.activate(mktempdir())
+    Pkg.develop(path = joinpath(@__DIR__, ".."))   # the project that contains this notebook
+    Pkg.add(["Plots", "PlutoUI"])                    # anything else the notebook needs
+    using MyLocalPackage, Plots, PlutoUI
+end
+```
+
+Activating the project itself (`Pkg.activate(joinpath(@__DIR__, ".."))`) also works when it already has every package the notebook needs. Never `Pkg.add` into the user's project from a notebook cell — that edits their `Project.toml` and `Manifest.toml` as a side effect. If a package is missing there, use the temporary-environment recipe above instead.
+
+Rules that follow from this:
+
+- Once a cell calls `Pkg.activate`, Pluto's automatic package installation is **off** for the whole notebook. Every package must be provided by that environment, and `using` lines outside the environment cell will fail until it has run.
+- The environment cell is slow (instantiate, precompile) — expect minutes on first run. Call `wait_for_notebook_idle` after editing it rather than retrying.
+- Keep it as one `begin ... end` cell; splitting the activation and the `using` lines across cells breaks because Pluto orders cells by data flow, not position.
+
+**Paths inside a Pluto notebook**
+
+- `@__DIR__` is the notebook file's directory and is the anchor for everything: `joinpath(@__DIR__, "..", "data", "x.csv")`.
+- `pwd()` is the Pluto server's working directory, not the notebook's. Do not rely on it and do not `cd`.
+- `@__FILE__` is the notebook path with a `#==#<cell id>` suffix; use `@__DIR__` instead.
+- Tool arguments (`path`, `output_path`, `new_path`) must be **absolute**: Pluto identifies a notebook by its absolute path, and the server cannot resolve a relative path against your working directory. The `npx @plutojl/cli call` command resolves relative paths for you; other clients must pass absolute paths.
+- Files the notebook writes (plots, exports, `read_cell_output` files) land where you say; default to `joinpath(@__DIR__, ...)` or `<notebook>.assets/`.
+
 ### Long computations and waiting
 
 - `create_cell`, `execute_cell`, and `execute_code` block until the cell finishes, but return after **5 minutes** with a `timed_out: true` message if it hasn't. The computation KEEPS RUNNING server-side — the response tells you how to pick up the result.
@@ -650,7 +682,7 @@ Aim for this top-to-bottom layout:
 3. **Key results and summary** — the main outputs, plots, or conclusions the reader cares about
 4. **Analysis sections** — the substantive work, organized under markdown headers
 5. **Boilerplate at the bottom** — helper functions, constants, and configuration cells
-6. **`Pkg` cells at the very end** — any manual `Pkg.activate` / `Pkg.add` cells should be the last cells in the notebook
+6. **One environment cell** — a manual `Pkg.activate` cell (see "Notebooks inside a Julia project") holds all its `using` lines; order in the file does not matter to Pluto, but keep it near the top so readers see what the notebook depends on
 
 Use `move_cells` to reorder cells into this layout.
 

--- a/src/__tests__/cli-toolArgs.test.ts
+++ b/src/__tests__/cli-toolArgs.test.ts
@@ -1,0 +1,46 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { readToolArgsSource, resolvePathArgs } from "../cli/toolArgs.ts";
+
+describe("resolvePathArgs", () => {
+  const cwd = path.join(os.tmpdir(), "proj");
+
+  it("resolves relative notebook and output paths against cwd", () => {
+    expect(
+      resolvePathArgs(
+        { path: "scripts/nb.pluto.jl", output_path: "out/x.png", cell_id: "c" },
+        cwd
+      )
+    ).toEqual({
+      path: path.join(cwd, "scripts/nb.pluto.jl"),
+      output_path: path.join(cwd, "out/x.png"),
+      cell_id: "c",
+    });
+  });
+
+  it("leaves absolute paths, empty strings, and non-strings alone", () => {
+    const args = { path: "/abs/nb.jl", new_path: "", code: 42 };
+    expect(resolvePathArgs(args, cwd)).toEqual(args);
+  });
+});
+
+describe("readToolArgsSource", () => {
+  it("returns inline JSON unchanged", () => {
+    expect(readToolArgsSource('{"a":1}', "/")).toBe('{"a":1}');
+  });
+
+  it("reads @file relative to cwd", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "plutocli-args-"));
+    try {
+      fs.writeFileSync(path.join(dir, "args.json"), '{"path":"nb.jl"}');
+      expect(readToolArgsSource("@args.json", dir)).toBe('{"path":"nb.jl"}');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("treats a lone @ as inline text", () => {
+    expect(readToolArgsSource("@", "/")).toBe("@");
+  });
+});

--- a/src/cli/call.ts
+++ b/src/cli/call.ts
@@ -8,6 +8,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { VERSION } from "./config.ts";
 import { extensionFor } from "../notebookOutput.ts";
+import { readToolArgsSource, resolvePathArgs } from "./toolArgs.ts";
 import { bold, cyan, dim, err, yellow } from "./ui.ts";
 
 interface ToolSchema {
@@ -273,6 +274,9 @@ export async function listTools(port: number, filter?: string): Promise<void> {
     return;
   }
 
+  console.log(
+    `  ${dim("Start with")} npx @plutojl/cli call learn_pluto_basics ${dim("— environments, paths, reactivity rules, and the workflow.")}\n`
+  );
   const maxLen = Math.max(...tools.map((t) => t.name.length));
   for (const tool of tools) {
     const params = Object.keys(tool.inputSchema?.properties ?? {});
@@ -300,30 +304,43 @@ export async function callTool(
   options: CallOptions
 ): Promise<void> {
   const { raw, timeoutMs, out } = options;
-  let args: unknown;
+  let source: string;
   try {
-    args = JSON.parse(argsJson);
-  } catch {
-    args = undefined;
-  }
-  if (args === null || typeof args !== "object" || Array.isArray(args)) {
+    source = readToolArgsSource(argsJson, process.cwd());
+  } catch (e) {
     console.error(
-      `${err.red("error:")} tool arguments must be a JSON object, got: ${argsJson}`
+      `${err.red("error:")} could not read tool arguments from ${argsJson}: ${e instanceof Error ? e.message : String(e)}`
+    );
+    process.exit(1);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    parsed = undefined;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    console.error(
+      `${err.red("error:")} tool arguments must be a JSON object, got: ${source.slice(0, 200)}`
     );
     console.error(
       err.dim(
-        `  e.g. npx @plutojl/cli call ${toolName} '{"path": "nb.pluto.jl"}'`
+        `  e.g. npx @plutojl/cli call ${toolName} '{"path": "nb.pluto.jl"}'  (or @args.json, or - for stdin)`
       )
     );
     process.exit(1);
   }
+  const args = resolvePathArgs(
+    parsed as Record<string, unknown>,
+    process.cwd()
+  );
 
   const result = await mcpRequest(
     port,
     "tools/call",
     {
       name: toolName,
-      arguments: args as Record<string, unknown>,
+      arguments: args,
     },
     timeoutMs
   );
@@ -338,10 +355,7 @@ export async function callTool(
       } else if (item.type === "image" && item.data) {
         // Never print base64 to the terminal: save the image and say where
         const ext = extensionFor(item.mimeType ?? "image/png");
-        const stem =
-          typeof (args as Record<string, unknown>).cell_id === "string"
-            ? String((args as Record<string, unknown>).cell_id)
-            : toolName;
+        const stem = typeof args.cell_id === "string" ? args.cell_id : toolName;
         const dest =
           out ??
           path.resolve(`${stem}${imageIndex ? `-${imageIndex}` : ""}.${ext}`);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -29,7 +29,7 @@ export function helpText(): string {
         "Show whether Pluto and a tool server are running (--wait blocks until both are)"
       ),
       cmd("tools", "List notebook tools; `tools <name>` shows its parameters"),
-      cmd("call", "Call a notebook tool: `call <tool> [json]`"),
+      cmd("call", "Call a notebook tool: `call <tool> [json | @file | -]`"),
       cmd("install", "Write MCP config so AI assistants can connect"),
       cmd("help", "Show this help"),
       cmd("version", "Print the version"),
@@ -72,6 +72,10 @@ export function helpText(): string {
       ),
       opt("--raw", "Print the raw JSON-RPC result"),
       opt("--out <file>", "Where to save an image returned by the tool"),
+      opt(
+        "",
+        `Relative ${dim("path")}/${dim("output_path")} arguments are resolved against the current directory`
+      ),
       opt("--mcp-port <port>", "Tool server to talk to"),
     ]),
     "",
@@ -91,6 +95,7 @@ export function helpText(): string {
     "",
     section("Examples", [
       `  ${CMD} run`,
+      `  ${CMD} call learn_pluto_basics        ${dim("# read this first")}`,
       `  ${CMD} run --pluto-url http://localhost:1234`,
       `  ${CMD} call open_notebook '{"path": "notebook.pluto.jl"}'`,
       `  ${CMD} call execute_code '{"code": "1 + 1"}'`,

--- a/src/cli/toolArgs.ts
+++ b/src/cli/toolArgs.ts
@@ -1,0 +1,38 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/** Tool arguments that name files; relative values are resolved against the caller's cwd. */
+const PATH_ARGS = ["path", "output_path", "new_path"];
+
+/**
+ * Turn the `call` argument into a JSON string: `-` reads stdin, `@file`
+ * reads a file, anything else is taken as the JSON itself.
+ */
+export function readToolArgsSource(arg: string, cwd: string): string {
+  if (arg === "-") {
+    return fs.readFileSync(0, "utf-8");
+  }
+  if (arg.startsWith("@") && arg.length > 1) {
+    return fs.readFileSync(path.resolve(cwd, arg.slice(1)), "utf-8");
+  }
+  return arg;
+}
+
+/**
+ * Notebook tools identify notebooks by absolute path (the server cannot
+ * know the caller's working directory), so resolve relative file
+ * arguments here, where that directory is known.
+ */
+export function resolvePathArgs(
+  args: Record<string, unknown>,
+  cwd: string
+): Record<string, unknown> {
+  const out = { ...args };
+  for (const key of PATH_ARGS) {
+    const value = out[key];
+    if (typeof value === "string" && value !== "" && !path.isAbsolute(value)) {
+      out[key] = path.resolve(cwd, value);
+    }
+  }
+  return out;
+}

--- a/src/mcp-server-http.ts
+++ b/src/mcp-server-http.ts
@@ -132,7 +132,7 @@ export class PlutoMCPHttpServer {
     // Learn Pluto Basics
     server.tool(
       "learn_pluto_basics",
-      "Get comprehensive guide on Pluto.jl notebook structure, reactivity, PlutoUI components, and best practices",
+      "Read this first. The guide to working with Pluto notebooks through these tools: the recommended workflow, reactivity rules (one definition per variable), package environments — including notebooks inside a Julia project that load a local package — how paths work inside Pluto, PlutoUI, and how to read outputs and plots.",
       {},
       async () => {
         return {
@@ -290,7 +290,7 @@ export class PlutoMCPHttpServer {
       "open_notebook",
       "Open a Pluto notebook file and create a worker session. The .jl file must already exist on disk — Pluto will not create a new file from a nonexistent path. Create the file first if needed.",
       {
-        path: z.string().describe("Path to the .jl notebook file"),
+        path: z.string().describe("Absolute path to the .jl notebook file"),
       },
       async ({ path }) => {
         if (!this.plutoManager.isConnected()) {
@@ -387,7 +387,7 @@ export class PlutoMCPHttpServer {
         }
 
         const outcome = await withExecutionTimeout(
-          this.plutoManager.executeCell(worker, cell_id, cellData.input.code)
+          this.plutoManager.runCell(worker, cell_id)
         );
 
         if (outcome.timedOut) {
@@ -497,7 +497,7 @@ export class PlutoMCPHttpServer {
     // Edit Cell
     server.tool(
       "edit_cell",
-      "Update the code of an existing cell. Note: editing the .pluto.jl file on disk has NO effect on the running notebook — all mutations must go through the MCP API. Use save_notebook to persist changes to disk.",
+      "Update the code of an existing cell and, by default, run it; the result returned is the cell's output after that run. Editing the .pluto.jl file on disk has NO effect on the running notebook — all mutations must go through these tools. Use save_notebook to persist changes to disk.",
       {
         path: z.string().describe("Path to the notebook"),
         cell_id: z.string().describe("UUID of the cell to edit"),
@@ -524,7 +524,7 @@ export class PlutoMCPHttpServer {
         if (run) {
           result = await this.plutoManager.executeCell(worker, cell_id, code);
         } else {
-          await worker.updateSnippetCode(cell_id, code, false);
+          await this.plutoManager.setCellCode(worker, cell_id, code);
         }
 
         return {
@@ -538,8 +538,8 @@ export class PlutoMCPHttpServer {
                   runtime: result?.runtime,
                   errored: result?.errored,
                   message: run
-                    ? "Cell updated and executed successfully"
-                    : "Cell code updated (not executed)",
+                    ? "Cell updated and executed"
+                    : "Cell code updated in Pluto (not executed; run it with execute_cell)",
                 },
                 null,
                 2

--- a/src/plutoManager.ts
+++ b/src/plutoManager.ts
@@ -1,5 +1,6 @@
 import type { CellResultData, Worker } from "@plutojl/rainbow";
 import { Host, serialize } from "@plutojl/rainbow";
+import * as path from "path";
 import type { IPlutoServerManager, IFileReader } from "./plutoManagerTypes.ts";
 import { EventEmitter } from "events";
 import { unlink } from "fs/promises";
@@ -328,6 +329,11 @@ export class PlutoManager {
     notebookPath: string,
     documentContent?: string
   ): Promise<Worker | undefined> {
+    if (!path.isAbsolute(notebookPath)) {
+      throw new Error(
+        `Notebook paths must be absolute — Pluto identifies a notebook by its absolute path and cannot resolve '${notebookPath}' against your working directory. Pass the full path.`
+      );
+    }
     if (!this.isConnected()) {
       await this.start();
     }
@@ -507,20 +513,107 @@ export class PlutoManager {
   /**
    * Execute a cell
    */
+  /**
+   * Send a cell's new code to Pluto without running it. The worker's own
+   * updateSnippetCode(run=false) only records the code locally, which
+   * neither save_notebook nor a later run would see.
+   */
+  public async setCellCode(
+    worker: Worker,
+    cellId: string,
+    code: string
+  ): Promise<void> {
+    await this.updateNotebookState(worker, (nb) => {
+      const input = nb.cell_inputs[cellId];
+      if (!input) {
+        throw new Error(`Cell ${cellId} not found`);
+      }
+      input.code = code;
+    });
+  }
+
+  /** Run a cell with whatever code Pluto currently holds for it, and wait for the result. */
+  public async runCell(
+    worker: Worker,
+    cellId: string
+  ): Promise<CellResultData | null> {
+    if (!worker.client) {
+      throw new Error("Not connected to notebook");
+    }
+    const before =
+      worker.getSnippet(cellId)?.result.output?.last_run_timestamp ?? 0;
+    await worker.client.send(
+      "run_multiple_cells",
+      { cells: [cellId] },
+      { notebook_id: worker.notebook_id }
+    );
+    return await this.waitForCellRun(worker, cellId, before);
+  }
+
+  /** Replace a cell's code, run it, and return the result of that run. */
   public async executeCell(
     worker: Worker,
     cellId: string,
     code: string
   ): Promise<CellResultData | null> {
-    // Update existing cell code and run it
-    await worker.updateSnippetCode(cellId, code, true);
+    await this.setCellCode(worker, cellId, code);
+    return await this.runCell(worker, cellId);
+  }
 
-    // Wait for execution to complete
-    // await worker.wait(true);
+  /**
+   * Mutate the worker's notebook state through its own updater, which
+   * diffs the change, sends it to Pluto, and keeps the local copy in sync.
+   */
+  private async updateNotebookState(
+    worker: Worker,
+    mutate: (nb: {
+      cell_inputs: Record<
+        string,
+        { code: string; code_folded: boolean; [key: string]: unknown }
+      >;
+    }) => void
+  ): Promise<void> {
+    if (!worker.client || !worker.notebook_state) {
+      throw new Error("Not connected to notebook");
+    }
+    await (
+      worker as unknown as {
+        _update_notebook_state: (fn: typeof mutate) => Promise<void>;
+      }
+    )._update_notebook_state(mutate);
+  }
 
-    // Get cell result
-    const cellData = worker.getSnippet(cellId);
-    return cellData?.result ?? null;
+  /**
+   * Wait until a cell has run since `before`. Pluto may decide not to run
+   * a cell at all (e.g. a parse error), so give it a few seconds to pick
+   * the cell up before returning whatever result it holds.
+   */
+  private async waitForCellRun(
+    worker: Worker,
+    cellId: string,
+    before: number,
+    limitMs = 60 * 60_000
+  ): Promise<CellResultData | null> {
+    const start = Date.now();
+    const pickupDeadline = start + 5_000;
+    let seenBusy = false;
+    while (Date.now() - start < limitMs) {
+      const result = worker.getSnippet(cellId)?.result;
+      if (!result) {
+        return null;
+      }
+      const busy = result.running || result.queued;
+      seenBusy ||= busy;
+      const stamp = result.output?.last_run_timestamp ?? 0;
+      if (!busy && stamp > before) {
+        return result;
+      }
+      if (!busy && !seenBusy && Date.now() > pickupDeadline) {
+        return result;
+      }
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    throw new Error("Timed out waiting for cell execution to finish");
   }
 
   /**
@@ -581,17 +674,7 @@ export class PlutoManager {
       return;
     }
 
-    // Route through the worker's own state updater so the local notebook
-    // state (which list_cells and save_notebook read) and Pluto stay in sync
-    await (
-      worker as unknown as {
-        _update_notebook_state: (
-          mutate: (nb: {
-            cell_inputs: Record<string, { code_folded: boolean }>;
-          }) => void
-        ) => Promise<void>;
-      }
-    )._update_notebook_state((nb) => {
+    await this.updateNotebookState(worker, (nb) => {
       nb.cell_inputs[cellId].code_folded = folded;
     });
   }


### PR DESCRIPTION
Source: a Dyad Agent session (Opus, no shell tool, drove the CLI through Julia's `run`) that successfully built a notebook inside a package repo but burned most of its effort on one environment cell and on cell edits that silently did nothing.

## Bugs fixed
- **`edit_cell` with `run: false` never reached Pluto.** The client library only records the code locally; `save_notebook` and a later `execute_cell` used the old code. Code changes now go through the worker's notebook-state update.
- **`execute_cell` could not re-run a cell.** It re-sent the server's own code, saw no change, and returned without running. It now sends an explicit run request.
- **`edit_cell` / `execute_cell` returned before the run.** Results came back with empty output, timestamp 0, and "executed successfully". They now wait for the run to settle, with a 5 s pickup grace for cells Pluto declines to run (parse errors), and the message no longer overstates.
- **Relative notebook paths** made a second worker keyed by the relative string that Pluto resolved against its own cwd. The server rejects them with an explanation; the CLI resolves `path`, `output_path`, `new_path` against the caller's directory first.

## Features
- `call <tool> @args.json` and `call <tool> -` (stdin) for the JSON argument.
- `learn_pluto_basics` says "Read this first" and lists what it covers; the `tools` listing and help examples point at it. The agent never opened the guide.

## Guide
New section **Notebooks inside a Julia project (local packages, environments, paths)**: one environment cell with `Pkg.activate(mktempdir()); Pkg.develop(path=joinpath(@__DIR__, ".."))` and the `using` lines in the same cell; never `Pkg.add` into the user's project; automatic package installation stops after `Pkg.activate`; `@__DIR__` vs `pwd()` vs `@__FILE__`; tool paths must be absolute.

## Verified live
`run:false` code runs on `execute_cell` and appears in the saved file; unchanged code re-runs (timestamp advances); a 2 s cell returns `42` with its runtime; a parse error returns in ~2 s; folding still persists; `@args.json` and a relative `create_notebook` path both work from the CLI; a raw relative path over MCP is refused with the explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DktWo8yNPTKr9kd2P6RT2
