### PR TITLE
feat(notebook): show Pluto's hidden cells with their code collapsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This extension contributes the following settings:
 - `pluto-notebook.port`: Port number for the Pluto server (default: 1234)
 - `pluto-notebook.mcpPort`: Port number for the MCP HTTP server (default: 3100)
 - `pluto-notebook.autoStartMcpServer`: Automatically start the MCP HTTP server when the extension activates (default: true)
+- `pluto-notebook.foldHiddenCells`: Show cells that Pluto marks as hidden (`╟─` in the file) with their code collapsed, as Pluto does (default: `true`). Collapsing or expanding a cell's input in VS Code updates the fold state in Pluto and in the saved file.
 - `pluto-notebook.juliaVersion`: Fallback Julia version for juliaup when the Julia extension is unavailable. Normally the active Julia channel (e.g. `julia.executablePath` in workspace settings, or the juliaup default) comes from the Julia extension.
 
 ## Available Commands

--- a/package.json
+++ b/package.json
@@ -56,6 +56,11 @@
           "default": true,
           "description": "Automatically start the MCP HTTP server when the extension activates"
         },
+        "pluto-notebook.foldHiddenCells": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show cells that Pluto marks as hidden (╟─ in the file) with their code collapsed, as Pluto does. Collapsing or expanding a cell's input in VS Code updates the notebook's fold state in Pluto."
+        },
         "pluto-notebook.juliaVersion": {
           "type": "string",
           "default": "",

--- a/src/__tests__/plutoSerializer.test.ts
+++ b/src/__tests__/plutoSerializer.test.ts
@@ -401,3 +401,65 @@ x = 1`;
     });
   });
 });
+
+describe("folded cells ↔ VS Code collapsed input", () => {
+  const src = `### A Pluto.jl notebook ###
+# v0.20.0
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ aaaaaaaa-0000-0000-0000-000000000001
+x = 1
+
+# ╔═╡ bbbbbbbb-0000-0000-0000-000000000002
+md"""
+# Title
+"""
+
+# ╔═╡ Cell order:
+# ╟─bbbbbbbb-0000-0000-0000-000000000002
+# ╠═aaaaaaaa-0000-0000-0000-000000000001
+`;
+
+  it("collapses folded cells by default and leaves the rest alone", () => {
+    const parsed = parsePlutoNotebook(src);
+    const [title, code] = parsed.cells;
+    expect(title.metadata?.code_folded).toBe(true);
+    expect(title.metadata?.inputCollapsed).toBe(true);
+    expect(code.metadata?.code_folded).toBe(false);
+    expect(code.metadata?.inputCollapsed).toBeUndefined();
+  });
+
+  it("does not touch the collapsed state when the option is off", () => {
+    const parsed = parsePlutoNotebook(src, { foldHiddenCells: false });
+    expect(parsed.cells[0].metadata?.code_folded).toBe(true);
+    expect(parsed.cells[0].metadata?.inputCollapsed).toBeUndefined();
+  });
+
+  it("writes the editor's collapsed state back as the fold marker", () => {
+    const cells = parsePlutoNotebook(src).cells;
+    // user expanded the title cell and collapsed the code cell
+    cells[0].metadata = { ...cells[0].metadata, inputCollapsed: false };
+    cells[1].metadata = {
+      ...cells[1].metadata,
+      inputCollapsed: true,
+      outputCollapsed: true,
+    };
+    const out = serializePlutoNotebook(cells, "nb", "0.20.0");
+    expect(out).toContain("# ╠═bbbbbbbb-0000-0000-0000-000000000002");
+    expect(out).toContain("# ╟─aaaaaaaa-0000-0000-0000-000000000001");
+    expect(out).not.toContain("inputCollapsed");
+    expect(out).not.toContain("outputCollapsed");
+  });
+
+  it("ignores the collapsed state when the option is off", () => {
+    const cells = parsePlutoNotebook(src, { foldHiddenCells: false }).cells;
+    cells[0].metadata = { ...cells[0].metadata, inputCollapsed: false };
+    const out = serializePlutoNotebook(cells, "nb", "0.20.0", {
+      foldHiddenCells: false,
+    });
+    expect(out).toContain("# ╟─bbbbbbbb-0000-0000-0000-000000000002");
+    expect(out).not.toContain("inputCollapsed");
+  });
+});

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -7,7 +7,7 @@ import type {
   NotebookData,
   UpdateEvent,
 } from "@plutojl/rainbow";
-import { formatCellOutput } from "./serializer.ts";
+import { formatCellOutput, serializerOptions } from "./serializer.ts";
 import {
   extractMarkdownContent,
   createVsCodeCellFromPlutoCell,
@@ -150,6 +150,15 @@ export class PlutoNotebookController {
           void this.renderCurrentState(notebook);
         } else {
           this.selectedNotebooks.delete(key);
+        }
+      }),
+      vscode.workspace.onDidChangeConfiguration((event) => {
+        if (event.affectsConfiguration("pluto-notebook.foldHiddenCells")) {
+          for (const notebook of vscode.workspace.notebookDocuments) {
+            if (notebook.notebookType === this.notebookType) {
+              void this.applyFoldSetting(notebook);
+            }
+          }
         }
       }),
       vscode.window.onDidChangeVisibleNotebookEditors((editors) => {
@@ -841,6 +850,104 @@ export class PlutoNotebookController {
    * Applies a Pluto-side code edit to the matching VSCode cell's text.
    * A patch matching the cell's current text is an echo and is dropped.
    */
+  /**
+   * Set a cell's fold-related metadata in the document. code_folded is
+   * what the serializer writes; inputCollapsed is what VS Code displays.
+   */
+  private async setCellFoldMetadata(
+    notebook: vscode.NotebookDocument,
+    cell: vscode.NotebookCell,
+    folded: boolean,
+    collapse: boolean
+  ): Promise<void> {
+    const current = cell.metadata ?? {};
+    const next: Record<string, unknown> = { ...current, code_folded: folded };
+    if (collapse) {
+      next.inputCollapsed = folded;
+    } else {
+      delete next.inputCollapsed;
+    }
+    if (
+      current.code_folded === next.code_folded &&
+      current.inputCollapsed === next.inputCollapsed
+    ) {
+      return;
+    }
+    const notebookPath = notebook.uri.fsPath;
+    this.beginRemoteEdit(notebookPath);
+    try {
+      const edit = new vscode.WorkspaceEdit();
+      edit.set(notebook.uri, [
+        vscode.NotebookEdit.updateCellMetadata(cell.index, next),
+      ]);
+      await vscode.workspace.applyEdit(edit);
+    } finally {
+      this.endRemoteEditSoon(notebookPath);
+    }
+  }
+
+  /** Pluto folded or unfolded a cell (browser UI, fold_cell): reflect it in the editor. */
+  private async _applyRemoteFold(
+    notebook: vscode.NotebookDocument,
+    cellId: CellId,
+    folded: boolean
+  ): Promise<void> {
+    const cell = this.getCellByPlutoId(notebook, cellId);
+    if (!cell) {
+      return;
+    }
+    await this.setCellFoldMetadata(
+      notebook,
+      cell,
+      folded,
+      serializerOptions().foldHiddenCells
+    );
+    this.outputChannel.appendLine(
+      `[FoldSync] Cell ${cellId} ${folded ? "folded" : "unfolded"} from Pluto`
+    );
+  }
+
+  /** The user collapsed or expanded a cell's input in VS Code: fold it in Pluto. */
+  private async handleVscodeMetadataChange(
+    notebook: vscode.NotebookDocument,
+    cell: vscode.NotebookCell
+  ): Promise<void> {
+    if (!serializerOptions().foldHiddenCells) {
+      return;
+    }
+    const cellId = cell.metadata?.pluto_cell_id as CellId | undefined;
+    if (!cellId) {
+      return;
+    }
+    const collapsed = cell.metadata?.inputCollapsed === true;
+    if (collapsed === (cell.metadata?.code_folded === true)) {
+      return;
+    }
+    await this.setCellFoldMetadata(notebook, cell, collapsed, true);
+    const worker = await this.plutoManager.getWorker(notebook.uri.fsPath);
+    if (worker) {
+      await this.plutoManager.foldCell(worker, cellId, collapsed);
+      this.outputChannel.appendLine(
+        `[FoldSync] Cell ${cellId} ${collapsed ? "folded" : "unfolded"} in Pluto`
+      );
+    }
+  }
+
+  /** Re-apply the fold setting to every cell of an open notebook. */
+  private async applyFoldSetting(
+    notebook: vscode.NotebookDocument
+  ): Promise<void> {
+    const collapse = serializerOptions().foldHiddenCells;
+    for (const cell of notebook.getCells()) {
+      await this.setCellFoldMetadata(
+        notebook,
+        cell,
+        cell.metadata?.code_folded === true,
+        collapse
+      );
+    }
+  }
+
   private async _applyRemoteCodeEdit(
     notebook: vscode.NotebookDocument,
     cellId: CellId,
@@ -986,9 +1093,22 @@ export class PlutoNotebookController {
                   );
                 });
               }
-              // Other cell_inputs fields (cell_id, code_folded, metadata)
-              // have no document representation to update; structural
-              // add/remove is handled via cell_order sync
+              if (rest[1] === "code_folded" && patch.op === "replace") {
+                void this._applyRemoteFold(
+                  notebook,
+                  rest[0] as CellId,
+                  patch.value === true
+                ).catch((error) => {
+                  this.outputChannel.appendLine(
+                    `[FoldSync] Failed for ${rest[0]}: ${
+                      error instanceof Error ? error.message : String(error)
+                    }`
+                  );
+                });
+              }
+              // Other cell_inputs fields (cell_id, metadata) have no
+              // document representation; structural add/remove is
+              // handled via cell_order sync
               break;
             }
             case "cell_results":
@@ -1269,11 +1389,13 @@ export class PlutoNotebookController {
       return;
     }
 
-    // Process cell changes
-    // for (const _change of event.cellChanges) {
-    // Handle cell metadata or output changes - we don't need to do anything here
-    // The worker will handle these through its update events
-    // }
+    // A collapsed/expanded input is the user folding a cell — mirror it
+    // into Pluto so the file and the browser view agree
+    for (const change of event.cellChanges) {
+      if (change.metadata !== undefined) {
+        await this.handleVscodeMetadataChange(notebook, change.cell);
+      }
+    }
 
     // A drag-reorder surfaces as the same pluto_cell_id in both the
     // removed and added lists — route those to moveCells; only genuine

--- a/src/plutoSerializer.ts
+++ b/src/plutoSerializer.ts
@@ -24,9 +24,19 @@ export interface ParsedNotebook {
 const fakeRegexTest = new RegExp(
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-7][0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 );
+export interface SerializerOptions {
+  /** Map Pluto's folded state to VS Code's collapsed-input state, both ways. */
+  foldHiddenCells: boolean;
+}
+
+export const DEFAULT_SERIALIZER_OPTIONS: SerializerOptions = {
+  foldHiddenCells: true,
+};
+
 export function createVsCodeCellFromPlutoCell(
   notebookData: NotebookData,
-  plutoCellId: string
+  plutoCellId: string,
+  options: SerializerOptions = DEFAULT_SERIALIZER_OPTIONS
 ): vscode.NotebookCellData | null {
   // Validate UUID format and check cell exists
   const cellInput = notebookData.cell_inputs[plutoCellId];
@@ -88,17 +98,24 @@ export function createVsCodeCellFromPlutoCell(
   // pluto_cell_id and code_folded come after the spread so values from the
   // cell marker/input always win over stale keys inside file metadata
   // (files written by older versions embedded pluto_cell_id as metadata)
+  const codeFolded = cellInput.code_folded ?? false;
   cellData.metadata = {
     ...cellInput.metadata,
     pluto_cell_id: plutoCellId,
-    code_folded: cellInput.code_folded ?? false,
+    code_folded: codeFolded,
+    // VS Code collapses a cell's input when this key is set, so Pluto's
+    // folded cells look the same in both editors
+    ...(options.foldHiddenCells && codeFolded ? { inputCollapsed: true } : {}),
   };
   return cellData;
 }
 /**
  * Parse a Pluto notebook file and extract cells
  */
-export function parsePlutoNotebook(content: string): ParsedNotebook {
+export function parsePlutoNotebook(
+  content: string,
+  options: SerializerOptions = DEFAULT_SERIALIZER_OPTIONS
+): ParsedNotebook {
   const notebookData = parse(content);
   const cells: vscode.NotebookCellData[] = [];
   if (isNotDefined(notebookData)) {
@@ -111,7 +128,7 @@ export function parsePlutoNotebook(content: string): ParsedNotebook {
   const cell_order =
     notebookData.cell_order ?? Object.keys(notebookData.cell_inputs);
   for (const cellId of cell_order) {
-    const cell = createVsCodeCellFromPlutoCell(notebookData, cellId);
+    const cell = createVsCodeCellFromPlutoCell(notebookData, cellId, options);
     if (isNotDefined(cell)) {
       continue;
     }
@@ -132,7 +149,8 @@ export function parsePlutoNotebook(content: string): ParsedNotebook {
 export function serializePlutoNotebook(
   cells: vscode.NotebookCellData[],
   notebookId?: string,
-  plutoVersion?: string
+  plutoVersion?: string,
+  options: SerializerOptions = DEFAULT_SERIALIZER_OPTIONS
 ): string {
   const cellInputs: Record<string, PlutoCellData> = {};
   const cellOrder: string[] = [];
@@ -156,8 +174,15 @@ export function serializePlutoNotebook(
       unknown
     >;
     delete plutoMetadata.pluto_cell_id;
-    const codeFolded = plutoMetadata.code_folded === true;
+    // The editor's collapsed state is the user's latest word on folding
+    const collapsed = plutoMetadata.inputCollapsed;
+    const codeFolded =
+      options.foldHiddenCells && typeof collapsed === "boolean"
+        ? collapsed
+        : plutoMetadata.code_folded === true;
     delete plutoMetadata.code_folded;
+    delete plutoMetadata.inputCollapsed;
+    delete plutoMetadata.outputCollapsed;
 
     cellInputs[cellId] = {
       cell_id: cellId,

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -1,8 +1,17 @@
 import * as vscode from "vscode";
 import {
+  type SerializerOptions,
   parsePlutoNotebook,
   serializePlutoNotebook,
 } from "./plutoSerializer.ts";
+
+export function serializerOptions(): SerializerOptions {
+  return {
+    foldHiddenCells: vscode.workspace
+      .getConfiguration("pluto-notebook")
+      .get<boolean>("foldHiddenCells", true),
+  };
+}
 import type { CellResultData } from "@plutojl/rainbow";
 
 export function formatCellOutput(
@@ -22,7 +31,7 @@ export class PlutoNotebookSerializer implements vscode.NotebookSerializer {
     const contents = new TextDecoder().decode(content);
 
     try {
-      const parsed = parsePlutoNotebook(contents);
+      const parsed = parsePlutoNotebook(contents, serializerOptions());
 
       // Create notebook data with metadata
       const notebookData = new vscode.NotebookData(parsed.cells);
@@ -59,7 +68,8 @@ export class PlutoNotebookSerializer implements vscode.NotebookSerializer {
     const serialized = serializePlutoNotebook(
       data.cells,
       data.metadata?.pluto_notebook_id as string,
-      data.metadata?.pluto_version as string
+      data.metadata?.pluto_version as string,
+      serializerOptions()
     );
 
     return new TextEncoder().encode(serialized);


### PR DESCRIPTION
Pluto hides the code of cells marked `╟─`; the extension showed all of it. Instead of removing cells from the document or replacing their code with a placeholder, this maps Pluto's fold state onto VS Code's own **collapsed input** state (the `inputCollapsed` cell-metadata key that the built-in "Collapse Cell Input" command and the Jupyter extension use). A folded cell shows a thin bar where its code was and its output at full size, and stays addressable, executable, and reports errors in place.

## Both directions
- **Open:** `code_folded` → `inputCollapsed: true`.
- **Editor → Pluto:** collapsing/expanding a cell's input updates `code_folded` in the document and calls `foldCell`, so the browser view and the file follow.
- **Pluto → editor:** a `cell_inputs.<id>.code_folded` patch (browser UI, `fold_cell` tool) updates the cell's metadata in the document.
- **Save:** the serializer treats the editor's collapsed state as the user's latest word and strips `inputCollapsed`/`outputCollapsed` from the metadata it writes, so nothing VS Code-internal leaks into `# ╠═╡` annotations.

## Setting
`pluto-notebook.foldHiddenCells`, default **true**. Turning it off expands all open notebooks and stops the sync; `code_folded` in the file is then honoured as before.

## Tests
Serializer round-trip tests for both option states; `tsc` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DktWo8yNPTKr9kd2P6RT2
