### PR TITLE
fix(server): report the Pluto port to the manager when it returns to the default

### DIFF
--- a/src/cli/nodeServerManager.ts
+++ b/src/cli/nodeServerManager.ts
@@ -34,6 +34,8 @@ function runProcess(
 export class NodeServerManager implements IPlutoServerManager {
   private juliaProcess?: ChildProcess;
   private actualPort: number;
+  /** Port the manager last heard about; every change is reported, including back to the default. */
+  private lastReportedPort: number;
   private starting = false;
   private onStopCallback?: () => void;
   private onPortChangedCallback?: (port: number) => void;
@@ -45,6 +47,7 @@ export class NodeServerManager implements IPlutoServerManager {
     private readonly options: { update?: boolean } = {}
   ) {
     this.actualPort = port;
+    this.lastReportedPort = port;
   }
 
   /** "default" (or "system") means: no juliaup channel pin, use whatever `julia` is. */
@@ -62,6 +65,19 @@ export class NodeServerManager implements IPlutoServerManager {
 
   onPortChanged(callback: (port: number) => void): void {
     this.onPortChangedCallback = callback;
+  }
+
+  /**
+   * Record the port the server actually uses and tell the manager when it
+   * differs from what it last heard — a return to the default port after
+   * a run on an alternative one is a change too.
+   */
+  private setActualPort(port: number): void {
+    this.actualPort = port;
+    if (port !== this.lastReportedPort) {
+      this.lastReportedPort = port;
+      this.onPortChangedCallback?.(port);
+    }
   }
 
   getActualPort(): number {
@@ -89,13 +105,10 @@ export class NodeServerManager implements IPlutoServerManager {
         console.log(
           `[pluto] Port ${this.port} is in use, finding alternative...`
         );
-        this.actualPort = await findAvailablePort(this.port);
+        this.setActualPort(await findAvailablePort(this.port));
         console.log(`[pluto] Using port ${this.actualPort}`);
-        if (this.actualPort !== this.port && this.onPortChangedCallback) {
-          this.onPortChangedCallback(this.actualPort);
-        }
       } else {
-        this.actualPort = this.port;
+        this.setActualPort(this.port);
       }
 
       // 2. Check Julia is available
@@ -203,7 +216,7 @@ export class NodeServerManager implements IPlutoServerManager {
         console.log(`[pluto] Julia process exited with code ${code}`);
         this.juliaProcess = undefined;
         this.starting = false;
-        this.actualPort = this.port;
+        this.setActualPort(this.port);
         this.onStopCallback?.();
       });
 
@@ -252,7 +265,7 @@ export class NodeServerManager implements IPlutoServerManager {
       }
     });
     this.juliaProcess = undefined;
-    this.actualPort = this.port;
+    this.setActualPort(this.port);
   }
 
   private async tryJuliaHubAuth(

--- a/src/plutoServerTask.ts
+++ b/src/plutoServerTask.ts
@@ -19,10 +19,13 @@ export class PlutoServerTaskManager {
   private taskEndListener?: vscode.Disposable;
   private isStarting = false;
   private actualPort: number;
+  /** Port the manager last heard about; every change is reported, including back to the default. */
+  private lastReportedPort: number;
   private onPortChangedCallback?: (newPort: number) => void;
 
   constructor(private readonly port = 1234) {
     this.actualPort = port;
+    this.lastReportedPort = port;
   }
 
   /**
@@ -44,6 +47,19 @@ export class PlutoServerTaskManager {
    */
   public onPortChanged(callback: (newPort: number) => void): void {
     this.onPortChangedCallback = callback;
+  }
+
+  /**
+   * Record the port the server actually uses and tell the manager when it
+   * differs from what it last heard — a return to the default port after
+   * a run on an alternative one is a change too.
+   */
+  private setActualPort(port: number): void {
+    this.actualPort = port;
+    if (port !== this.lastReportedPort) {
+      this.lastReportedPort = port;
+      this.onPortChangedCallback?.(port);
+    }
   }
 
   /**
@@ -76,8 +92,7 @@ export class PlutoServerTaskManager {
         // Adopt the reused task's port — it may differ from our configured one
         const taskPort = execution.task.definition.port as number | undefined;
         if (taskPort && taskPort !== this.actualPort) {
-          this.actualPort = taskPort;
-          this.onPortChangedCallback?.(taskPort);
+          this.setActualPort(taskPort);
         }
 
         // Watch the adopted task for termination like a task we started
@@ -87,7 +102,7 @@ export class PlutoServerTaskManager {
             this.serverReadyPromise = undefined;
             this.serverReadyResolve = undefined;
             this.isStarting = false;
-            this.actualPort = this.port;
+            this.setActualPort(this.port);
             this.taskEndListener?.dispose();
             this.taskEndListener = undefined;
             this.onStopCallback?.();
@@ -107,14 +122,10 @@ export class PlutoServerTaskManager {
         `[PlutoServerTask] Port ${this.port} is not available, finding alternative...`
       );
       try {
-        this.actualPort = await findAvailablePort(this.port);
+        this.setActualPort(await findAvailablePort(this.port));
         console.log(
           `[PlutoServerTask] Found available port: ${this.actualPort}`
         );
-
-        if (this.onPortChangedCallback && this.actualPort !== this.port) {
-          this.onPortChangedCallback(this.actualPort);
-        }
 
         if (this.actualPort !== this.port) {
           vscode.window.showWarningMessage(
@@ -128,7 +139,7 @@ export class PlutoServerTaskManager {
         throw new Error(`Failed to find available port: ${errorMessage}`);
       }
     } else {
-      this.actualPort = this.port;
+      this.setActualPort(this.port);
     }
 
     // Create promise that resolves when server is ready
@@ -235,7 +246,7 @@ export class PlutoServerTaskManager {
         this.serverReadyPromise = undefined;
         this.serverReadyResolve = undefined;
         this.isStarting = false;
-        this.actualPort = this.port;
+        this.setActualPort(this.port);
 
         if (this.taskEndListener) {
           this.taskEndListener.dispose();
@@ -345,7 +356,7 @@ export class PlutoServerTaskManager {
       this.taskEndListener = undefined;
     }
 
-    this.actualPort = this.port;
+    this.setActualPort(this.port);
   }
 
   /**


### PR DESCRIPTION
## Symptom
The extension insisted Pluto was at `http://localhost:1235` (every execution failed with `Cannot reach Pluto server at http://localhost:1235`) while its own Julia process was listening on 1234, started with `Pluto.run(port=1234)`.

## Cause
When port 1234 was busy at an earlier start (e.g. a `npx @plutojl/cli run` in a terminal), `PlutoServerTask` picked 1235 and reported it through `onPortChanged`, so `PlutoManager` switched its URL. When that server stopped and a new one started with 1234 free, the task set `actualPort = port` in the default branch, in the task-end handler, and in `stop()` **without reporting**, so the manager kept 1235 forever. The CLI's `NodeServerManager` had the same shape.

## Fix
One `setActualPort()` per manager that reports whenever the effective port differs from what the manager last heard, including a return to the default. The explicit callback calls that only fired for a move *away* from the default are gone.

## Repairing an affected window today
Reload the window (the manager is rebuilt with the configured URL and adopts the running task's port). Stop/start does not help on the released version, which is exactly this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DktWo8yNPTKr9kd2P6RT2
