### PR TITLE
fix(notebook): collapse folded cells through VS Code's own commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This extension contributes the following settings:
 - `pluto-notebook.port`: Port number for the Pluto server (default: 1234)
 - `pluto-notebook.mcpPort`: Port number for the MCP HTTP server (default: 3100)
 - `pluto-notebook.autoStartMcpServer`: Automatically start the MCP HTTP server when the extension activates (default: true)
-- `pluto-notebook.foldHiddenCells`: Show cells that Pluto marks as hidden (`╟─` in the file) with their code collapsed, as Pluto does (default: `true`). Collapsing or expanding a cell's input in VS Code updates the fold state in Pluto and in the saved file.
+- `pluto-notebook.foldHiddenCells`: Show cells that Pluto marks as hidden (`╟─` in the file) with their code collapsed, as Pluto does (default: `true`). Folds made in Pluto or by `fold_cell` collapse the cell in the editor; collapsing a cell by hand in VS Code does not change the file.
 - `pluto-notebook.juliaVersion`: Fallback Julia version for juliaup when the Julia extension is unavailable. Normally the active Julia channel (e.g. `julia.executablePath` in workspace settings, or the juliaup default) comes from the Julia extension.
 
 ## Available Commands

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "pluto-notebook.foldHiddenCells": {
           "type": "boolean",
           "default": true,
-          "description": "Show cells that Pluto marks as hidden (╟─ in the file) with their code collapsed, as Pluto does. Collapsing or expanding a cell's input in VS Code updates the notebook's fold state in Pluto."
+          "description": "Show cells that Pluto marks as hidden (╟─ in the file) with their code collapsed, as Pluto does. Folds made in Pluto or by fold_cell collapse the cell in the editor; collapsing a cell by hand in VS Code does not change the file."
         },
         "pluto-notebook.juliaVersion": {
           "type": "string",

--- a/src/__tests__/plutoSerializer.test.ts
+++ b/src/__tests__/plutoSerializer.test.ts
@@ -402,7 +402,7 @@ x = 1`;
   });
 });
 
-describe("folded cells ↔ VS Code collapsed input", () => {
+describe("folded cells", () => {
   const src = `### A Pluto.jl notebook ###
 # v0.20.0
 
@@ -422,27 +422,18 @@ md"""
 # ╠═aaaaaaaa-0000-0000-0000-000000000001
 `;
 
-  it("collapses folded cells by default and leaves the rest alone", () => {
-    const parsed = parsePlutoNotebook(src);
-    const [title, code] = parsed.cells;
+  it("carries the fold marker as code_folded metadata", () => {
+    const [title, code] = parsePlutoNotebook(src).cells;
     expect(title.metadata?.code_folded).toBe(true);
-    expect(title.metadata?.inputCollapsed).toBe(true);
     expect(code.metadata?.code_folded).toBe(false);
-    expect(code.metadata?.inputCollapsed).toBeUndefined();
   });
 
-  it("does not touch the collapsed state when the option is off", () => {
-    const parsed = parsePlutoNotebook(src, { foldHiddenCells: false });
-    expect(parsed.cells[0].metadata?.code_folded).toBe(true);
-    expect(parsed.cells[0].metadata?.inputCollapsed).toBeUndefined();
-  });
-
-  it("writes the editor's collapsed state back as the fold marker", () => {
+  it("writes code_folded back as the fold marker and drops editor-internal keys", () => {
     const cells = parsePlutoNotebook(src).cells;
-    // user expanded the title cell and collapsed the code cell
-    cells[0].metadata = { ...cells[0].metadata, inputCollapsed: false };
+    cells[0].metadata = { ...cells[0].metadata, code_folded: false };
     cells[1].metadata = {
       ...cells[1].metadata,
+      code_folded: true,
       inputCollapsed: true,
       outputCollapsed: true,
     };
@@ -451,15 +442,5 @@ md"""
     expect(out).toContain("# ╟─aaaaaaaa-0000-0000-0000-000000000001");
     expect(out).not.toContain("inputCollapsed");
     expect(out).not.toContain("outputCollapsed");
-  });
-
-  it("ignores the collapsed state when the option is off", () => {
-    const cells = parsePlutoNotebook(src, { foldHiddenCells: false }).cells;
-    cells[0].metadata = { ...cells[0].metadata, inputCollapsed: false };
-    const out = serializePlutoNotebook(cells, "nb", "0.20.0", {
-      foldHiddenCells: false,
-    });
-    expect(out).toContain("# ╟─bbbbbbbb-0000-0000-0000-000000000002");
-    expect(out).not.toContain("inputCollapsed");
   });
 });

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -7,7 +7,7 @@ import type {
   NotebookData,
   UpdateEvent,
 } from "@plutojl/rainbow";
-import { formatCellOutput, serializerOptions } from "./serializer.ts";
+import { formatCellOutput, foldHiddenCellsEnabled } from "./serializer.ts";
 import {
   extractMarkdownContent,
   createVsCodeCellFromPlutoCell,
@@ -74,6 +74,8 @@ export class PlutoNotebookController {
   private readonly selectedNotebooks: Set<string> = new Set();
   private readonly selectionAttempts: Map<string, Promise<void>> = new Map();
   private readonly listeners: vscode.Disposable[] = [];
+  /** Notebooks whose folded cells have been collapsed in an editor once. */
+  private readonly foldsApplied: Set<string> = new Set();
 
   private executeHandler = (
     cells: vscode.NotebookCell[],
@@ -165,6 +167,7 @@ export class PlutoNotebookController {
         for (const editor of editors) {
           if (editor.notebook.notebookType === this.notebookType) {
             void this.ensureSelected(editor.notebook);
+            void this.applyFoldsOnce(editor.notebook);
           }
         }
       })
@@ -851,38 +854,64 @@ export class PlutoNotebookController {
    * A patch matching the cell's current text is an echo and is dropped.
    */
   /**
-   * Set a cell's fold-related metadata in the document. code_folded is
-   * what the serializer writes; inputCollapsed is what VS Code displays.
+   * Collapse or expand cells' input in the editors showing a notebook.
+   * VS Code keeps this state inside the editor and exposes it only
+   * through its collapse/expand commands, which take cell index ranges.
    */
-  private async setCellFoldMetadata(
+  private async setInputCollapsed(
     notebook: vscode.NotebookDocument,
-    cell: vscode.NotebookCell,
-    folded: boolean,
-    collapse: boolean
+    cells: vscode.NotebookCell[],
+    collapsed: boolean
   ): Promise<void> {
-    const current = cell.metadata ?? {};
-    const next: Record<string, unknown> = { ...current, code_folded: folded };
-    if (collapse) {
-      next.inputCollapsed = folded;
-    } else {
-      delete next.inputCollapsed;
-    }
-    if (
-      current.code_folded === next.code_folded &&
-      current.inputCollapsed === next.inputCollapsed
-    ) {
+    if (cells.length === 0) {
       return;
     }
-    const notebookPath = notebook.uri.fsPath;
-    this.beginRemoteEdit(notebookPath);
+    const shown = vscode.window.visibleNotebookEditors.some(
+      (e) => e.notebook === notebook
+    );
+    if (!shown) {
+      return;
+    }
+    await vscode.commands.executeCommand(
+      collapsed
+        ? "notebook.cell.collapseCellInput"
+        : "notebook.cell.expandCellInput",
+      {
+        ranges: cells.map((c) => ({ start: c.index, end: c.index + 1 })),
+        document: notebook.uri,
+      }
+    );
+  }
+
+  private foldedCells(
+    notebook: vscode.NotebookDocument
+  ): vscode.NotebookCell[] {
+    return notebook.getCells().filter((c) => c.metadata?.code_folded === true);
+  }
+
+  /** Collapse the folded cells the first time a notebook is shown. */
+  private async applyFoldsOnce(
+    notebook: vscode.NotebookDocument
+  ): Promise<void> {
+    const key = notebook.uri.toString();
+    if (!foldHiddenCellsEnabled() || this.foldsApplied.has(key)) {
+      return;
+    }
+    const shown = vscode.window.visibleNotebookEditors.some(
+      (e) => e.notebook === notebook
+    );
+    if (!shown) {
+      return;
+    }
+    this.foldsApplied.add(key);
     try {
-      const edit = new vscode.WorkspaceEdit();
-      edit.set(notebook.uri, [
-        vscode.NotebookEdit.updateCellMetadata(cell.index, next),
-      ]);
-      await vscode.workspace.applyEdit(edit);
-    } finally {
-      this.endRemoteEditSoon(notebookPath);
+      await this.setInputCollapsed(notebook, this.foldedCells(notebook), true);
+    } catch (error) {
+      this.outputChannel.appendLine(
+        `[FoldSync] Could not collapse folded cells: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     }
   }
 
@@ -896,55 +925,41 @@ export class PlutoNotebookController {
     if (!cell) {
       return;
     }
-    await this.setCellFoldMetadata(
-      notebook,
-      cell,
-      folded,
-      serializerOptions().foldHiddenCells
-    );
+    if (cell.metadata?.code_folded !== folded) {
+      const notebookPath = notebook.uri.fsPath;
+      this.beginRemoteEdit(notebookPath);
+      try {
+        const edit = new vscode.WorkspaceEdit();
+        edit.set(notebook.uri, [
+          vscode.NotebookEdit.updateCellMetadata(cell.index, {
+            ...cell.metadata,
+            code_folded: folded,
+          }),
+        ]);
+        await vscode.workspace.applyEdit(edit);
+      } finally {
+        this.endRemoteEditSoon(notebookPath);
+      }
+    }
+    if (foldHiddenCellsEnabled()) {
+      await this.setInputCollapsed(notebook, [cell], folded);
+    }
     this.outputChannel.appendLine(
       `[FoldSync] Cell ${cellId} ${folded ? "folded" : "unfolded"} from Pluto`
     );
   }
 
-  /** The user collapsed or expanded a cell's input in VS Code: fold it in Pluto. */
-  private async handleVscodeMetadataChange(
-    notebook: vscode.NotebookDocument,
-    cell: vscode.NotebookCell
-  ): Promise<void> {
-    if (!serializerOptions().foldHiddenCells) {
-      return;
-    }
-    const cellId = cell.metadata?.pluto_cell_id as CellId | undefined;
-    if (!cellId) {
-      return;
-    }
-    const collapsed = cell.metadata?.inputCollapsed === true;
-    if (collapsed === (cell.metadata?.code_folded === true)) {
-      return;
-    }
-    await this.setCellFoldMetadata(notebook, cell, collapsed, true);
-    const worker = await this.plutoManager.getWorker(notebook.uri.fsPath);
-    if (worker) {
-      await this.plutoManager.foldCell(worker, cellId, collapsed);
-      this.outputChannel.appendLine(
-        `[FoldSync] Cell ${cellId} ${collapsed ? "folded" : "unfolded"} in Pluto`
-      );
-    }
-  }
-
-  /** Re-apply the fold setting to every cell of an open notebook. */
+  /** The setting changed: collapse folded cells, or expand them all. */
   private async applyFoldSetting(
     notebook: vscode.NotebookDocument
   ): Promise<void> {
-    const collapse = serializerOptions().foldHiddenCells;
-    for (const cell of notebook.getCells()) {
-      await this.setCellFoldMetadata(
-        notebook,
-        cell,
-        cell.metadata?.code_folded === true,
-        collapse
-      );
+    const folded = this.foldedCells(notebook);
+    if (foldHiddenCellsEnabled()) {
+      this.foldsApplied.add(notebook.uri.toString());
+      await this.setInputCollapsed(notebook, folded, true);
+    } else {
+      this.foldsApplied.delete(notebook.uri.toString());
+      await this.setInputCollapsed(notebook, folded, false);
     }
   }
 
@@ -1179,6 +1194,7 @@ export class PlutoNotebookController {
     if (notebook.notebookType === "pluto-notebook") {
       this.outputChannel.appendLine(`Notebook opened: ${notebook.uri.fsPath}`);
       void this.ensureSelected(notebook);
+      void this.applyFoldsOnce(notebook);
 
       // Only initialize if server is running
       if (this.plutoManager.isRunning()) {
@@ -1389,14 +1405,6 @@ export class PlutoNotebookController {
       return;
     }
 
-    // A collapsed/expanded input is the user folding a cell — mirror it
-    // into Pluto so the file and the browser view agree
-    for (const change of event.cellChanges) {
-      if (change.metadata !== undefined) {
-        await this.handleVscodeMetadataChange(notebook, change.cell);
-      }
-    }
-
     // A drag-reorder surfaces as the same pluto_cell_id in both the
     // removed and added lists — route those to moveCells; only genuine
     // additions and deletions go to the add/remove handlers
@@ -1456,6 +1464,7 @@ export class PlutoNotebookController {
    * Pluto's own UI may still be using the notebook.
    */
   public handleNotebookClosed(notebook: vscode.NotebookDocument): void {
+    this.foldsApplied.delete(notebook.uri.toString());
     if (notebook.notebookType !== "pluto-notebook") {
       return;
     }

--- a/src/plutoSerializer.ts
+++ b/src/plutoSerializer.ts
@@ -24,19 +24,9 @@ export interface ParsedNotebook {
 const fakeRegexTest = new RegExp(
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-7][0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 );
-export interface SerializerOptions {
-  /** Map Pluto's folded state to VS Code's collapsed-input state, both ways. */
-  foldHiddenCells: boolean;
-}
-
-export const DEFAULT_SERIALIZER_OPTIONS: SerializerOptions = {
-  foldHiddenCells: true,
-};
-
 export function createVsCodeCellFromPlutoCell(
   notebookData: NotebookData,
-  plutoCellId: string,
-  options: SerializerOptions = DEFAULT_SERIALIZER_OPTIONS
+  plutoCellId: string
 ): vscode.NotebookCellData | null {
   // Validate UUID format and check cell exists
   const cellInput = notebookData.cell_inputs[plutoCellId];
@@ -98,24 +88,17 @@ export function createVsCodeCellFromPlutoCell(
   // pluto_cell_id and code_folded come after the spread so values from the
   // cell marker/input always win over stale keys inside file metadata
   // (files written by older versions embedded pluto_cell_id as metadata)
-  const codeFolded = cellInput.code_folded ?? false;
   cellData.metadata = {
     ...cellInput.metadata,
     pluto_cell_id: plutoCellId,
-    code_folded: codeFolded,
-    // VS Code collapses a cell's input when this key is set, so Pluto's
-    // folded cells look the same in both editors
-    ...(options.foldHiddenCells && codeFolded ? { inputCollapsed: true } : {}),
+    code_folded: cellInput.code_folded ?? false,
   };
   return cellData;
 }
 /**
  * Parse a Pluto notebook file and extract cells
  */
-export function parsePlutoNotebook(
-  content: string,
-  options: SerializerOptions = DEFAULT_SERIALIZER_OPTIONS
-): ParsedNotebook {
+export function parsePlutoNotebook(content: string): ParsedNotebook {
   const notebookData = parse(content);
   const cells: vscode.NotebookCellData[] = [];
   if (isNotDefined(notebookData)) {
@@ -128,7 +111,7 @@ export function parsePlutoNotebook(
   const cell_order =
     notebookData.cell_order ?? Object.keys(notebookData.cell_inputs);
   for (const cellId of cell_order) {
-    const cell = createVsCodeCellFromPlutoCell(notebookData, cellId, options);
+    const cell = createVsCodeCellFromPlutoCell(notebookData, cellId);
     if (isNotDefined(cell)) {
       continue;
     }
@@ -149,8 +132,7 @@ export function parsePlutoNotebook(
 export function serializePlutoNotebook(
   cells: vscode.NotebookCellData[],
   notebookId?: string,
-  plutoVersion?: string,
-  options: SerializerOptions = DEFAULT_SERIALIZER_OPTIONS
+  plutoVersion?: string
 ): string {
   const cellInputs: Record<string, PlutoCellData> = {};
   const cellOrder: string[] = [];
@@ -174,13 +156,9 @@ export function serializePlutoNotebook(
       unknown
     >;
     delete plutoMetadata.pluto_cell_id;
-    // The editor's collapsed state is the user's latest word on folding
-    const collapsed = plutoMetadata.inputCollapsed;
-    const codeFolded =
-      options.foldHiddenCells && typeof collapsed === "boolean"
-        ? collapsed
-        : plutoMetadata.code_folded === true;
+    const codeFolded = plutoMetadata.code_folded === true;
     delete plutoMetadata.code_folded;
+    // Editor-internal keys, never part of a Pluto cell
     delete plutoMetadata.inputCollapsed;
     delete plutoMetadata.outputCollapsed;
 

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -1,16 +1,14 @@
 import * as vscode from "vscode";
 import {
-  type SerializerOptions,
   parsePlutoNotebook,
   serializePlutoNotebook,
 } from "./plutoSerializer.ts";
 
-export function serializerOptions(): SerializerOptions {
-  return {
-    foldHiddenCells: vscode.workspace
-      .getConfiguration("pluto-notebook")
-      .get<boolean>("foldHiddenCells", true),
-  };
+/** Whether Pluto's hidden cells should show with their input collapsed. */
+export function foldHiddenCellsEnabled(): boolean {
+  return vscode.workspace
+    .getConfiguration("pluto-notebook")
+    .get<boolean>("foldHiddenCells", true);
 }
 import type { CellResultData } from "@plutojl/rainbow";
 
@@ -31,7 +29,7 @@ export class PlutoNotebookSerializer implements vscode.NotebookSerializer {
     const contents = new TextDecoder().decode(content);
 
     try {
-      const parsed = parsePlutoNotebook(contents, serializerOptions());
+      const parsed = parsePlutoNotebook(contents);
 
       // Create notebook data with metadata
       const notebookData = new vscode.NotebookData(parsed.cells);
@@ -68,8 +66,7 @@ export class PlutoNotebookSerializer implements vscode.NotebookSerializer {
     const serialized = serializePlutoNotebook(
       data.cells,
       data.metadata?.pluto_notebook_id as string,
-      data.metadata?.pluto_version as string,
-      serializerOptions()
+      data.metadata?.pluto_version as string
     );
 
     return new TextEncoder().encode(serialized);


### PR DESCRIPTION
## Why 0.7.0 folding did nothing
It set `inputCollapsed` in cell metadata. VS Code never reads that key: a cell's collapsed input is editor-internal state (`isInputCollapsed` on the view cell) and the extension host has no translation for it. The only way in for an extension is the built-in commands.

## Fix
`notebook.cell.collapseCellInput` / `notebook.cell.expandCellInput` take `{ ranges: [{start, end}], document }` (same parser as the execute commands; verified in the VS Code 1.133 bundle that it resolves the editor by document and applies to exactly those cells). The controller now:
- collapses every `code_folded` cell the first time a notebook is shown (registration and `onDidChangeVisibleNotebookEditors`), once per document so a cell the user expanded by hand is not re-collapsed;
- collapses/expands the one cell when a fold patch arrives from Pluto (browser UI, `fold_cell`), after updating `code_folded` in the document;
- on the setting toggle, collapses all folded cells or expands them.
Calls are skipped when the notebook has no visible editor, which also avoids the parser's fallback to the active editor's selection.

## Scope reduction
VS Code does not report collapse changes to extensions, so folding a cell by hand in the editor cannot be synced to Pluto. The serializer keeps `code_folded` as the file's truth and strips editor-internal keys; the setting description no longer promises the reverse direction.

## Tests
Serializer tests updated (`code_folded` round trip, editor keys stripped); `tsc` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DktWo8yNPTKr9kd2P6RT2
